### PR TITLE
Correct case in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ If we now send a POST request to `http://localhost:3000/api` with a GraphQL Quer
 ```GraphQL
 query GetDeity {
   deity (name: "Morpheus") {
-    fullname
+    fullName
     power
   }
 }
@@ -110,7 +110,7 @@ our query will be resolved!
 {
   "data": {
     "deity": {
-      "fullname": "Morpheus",
+      "fullName": "Morpheus",
       "power": "Shapeshifting"
     }
   }


### PR DESCRIPTION
I followed the tutorial in `README.md` of the repo, to find the API server returns an error claiming:

> "Cannot query field \"fullname\" on type \"Deity\"

This was because the correct field name was not `fullname` but `fullName`.