### PR TITLE
Feature/Handle Reserved Names #207

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,18 @@ data DeityArgs = DeityArgs
 For each field in the `Query` type defined via `a -> ResM b` (like `deity`) we will define a resolver implementation that provides the values during runtime by referring to
 some data source, e.g. a database or another API. Fields that are defined without `a -> ResM b` you can just provide a value.
 
+In above example, the field of `DeityArgs` could also be named using reserved identities (such as: `type`, `where`, etc), in order to avoid conflict, a prime symbol (`'`) must be attached. For example, you can have:
+
+```haskell
+data DeityArgs = DeityArgs
+  { name      :: Text        -- Required Argument
+  , mythology :: Maybe Text  -- Optional Argument
+  , type'     :: Text
+  } deriving (Generic)
+```
+
+The field name in the final request will be `type` instead of `type'`. The Morpheus request parser converts each of the reserved identities in Haskell 2010 to their corresponding names internally. This also applies to selections.
+
 ```haskell
 resolveDeity :: DeityArgs -> ResM Deity
 resolveDeity args = gqlResolver $ askDB (name args) (mythology args)

--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,7 @@
   ```
 
   [details](https://github.com/morpheusgraphql/morpheus-graphql/issues/184)
+- `convertToJSONName` & `convertToHaskellName` has been extended to support all Haskell 2010 reserved identities. [details](https://github.com/morpheusgraphql/morpheus-graphql/issues/207)
 
 ### Fixed:
 

--- a/src/Data/Morpheus/Types/Internal/Value.hs
+++ b/src/Data/Morpheus/Types/Internal/Value.hs
@@ -14,60 +14,47 @@ import qualified Data.HashMap.Strict as M (toList)
 import           Data.Scientific     (Scientific, floatingOrInteger)
 import           Data.Semigroup      ((<>))
 import           Data.Text           (Text)
+import qualified Data.Text           as T
 import qualified Data.Vector         as V (toList)
 import           GHC.Generics        (Generic)
 
+isReserved :: Text -> Bool
+isReserved "case"     = True
+isReserved "class"    = True
+isReserved "data"     = True
+isReserved "default"  = True
+isReserved "deriving" = True
+isReserved "do"       = True
+isReserved "else"     = True
+isReserved "foreign"  = True
+isReserved "if"       = True
+isReserved "import"   = True
+isReserved "in"       = True
+isReserved "infix"    = True
+isReserved "infixl"   = True
+isReserved "infixr"   = True
+isReserved "instance" = True
+isReserved "let"      = True
+isReserved "module"   = True
+isReserved "newtype"  = True
+isReserved "of"       = True
+isReserved "then"     = True
+isReserved "type"     = True
+isReserved "where"    = True
+isReserved "_"        = True
+isReserved _          = False
+{-# INLINE isReserved #-}
+
 convertToJSONName :: Text -> Text
-convertToJSONName "case'"     = "case"
-convertToJSONName "class'"    = "class"
-convertToJSONName "data'"     = "data"
-convertToJSONName "default'"  = "default"
-convertToJSONName "deriving'" = "deriving"
-convertToJSONName "do'"       = "do"
-convertToJSONName "else'"     = "else"
-convertToJSONName "foreign'"  = "foreign"
-convertToJSONName "if'"       = "if"
-convertToJSONName "import'"   = "import"
-convertToJSONName "in'"       = "in"
-convertToJSONName "infix'"    = "infix"
-convertToJSONName "infixl'"   = "infixl"
-convertToJSONName "infixr'"   = "infixr"
-convertToJSONName "instance'" = "instance"
-convertToJSONName "let'"      = "let"
-convertToJSONName "module'"   = "module"
-convertToJSONName "newtype'"  = "newtype"
-convertToJSONName "of'"       = "of"
-convertToJSONName "then'"     = "then"
-convertToJSONName "type'"     = "type"
-convertToJSONName "where'"    = "where"
-convertToJSONName "_'"        = "_"
-convertToJSONName x           = x
+convertToJSONName hsName
+  | not (T.null hsName) && isReserved name && (T.last hsName == '\'') = name
+  | otherwise = hsName
+  where name = T.init hsName
 
 convertToHaskellName :: Text -> Text
-convertToHaskellName "case"     = "case'"
-convertToHaskellName "class"    = "class'"
-convertToHaskellName "data"     = "data'"
-convertToHaskellName "default"  = "default'"
-convertToHaskellName "deriving" = "deriving'"
-convertToHaskellName "do"       = "do'"
-convertToHaskellName "else"     = "else'"
-convertToHaskellName "foreign"  = "foreign'"
-convertToHaskellName "if"       = "if'"
-convertToHaskellName "import"   = "import'"
-convertToHaskellName "in"       = "in'"
-convertToHaskellName "infix"    = "infix'"
-convertToHaskellName "infixl"   = "infixl'"
-convertToHaskellName "infixr"   = "infixr'"
-convertToHaskellName "instance" = "instance'"
-convertToHaskellName "let"      = "let'"
-convertToHaskellName "module"   = "module'"
-convertToHaskellName "newtype"  = "newtype'"
-convertToHaskellName "of"       = "of'"
-convertToHaskellName "then"     = "then'"
-convertToHaskellName "type"     = "type'"
-convertToHaskellName "where"    = "where'"
-convertToHaskellName "_"        = "_'"
-convertToHaskellName x          = x
+convertToHaskellName name
+  | isReserved name = name <> "'"
+  | otherwise = name
 
 -- | Primitive Values for GQLScalar: 'Int', 'Float', 'String', 'Boolean'.
 -- for performance reason type 'Text' represents GraphQl 'String' value

--- a/src/Data/Morpheus/Types/Internal/Value.hs
+++ b/src/Data/Morpheus/Types/Internal/Value.hs
@@ -18,12 +18,56 @@ import qualified Data.Vector         as V (toList)
 import           GHC.Generics        (Generic)
 
 convertToJSONName :: Text -> Text
-convertToJSONName "type'" = "type"
-convertToJSONName x       = x
+convertToJSONName "case'"     = "case"
+convertToJSONName "class'"    = "class"
+convertToJSONName "data'"     = "data"
+convertToJSONName "default'"  = "default"
+convertToJSONName "deriving'" = "deriving"
+convertToJSONName "do'"       = "do"
+convertToJSONName "else'"     = "else"
+convertToJSONName "foreign'"  = "foreign"
+convertToJSONName "if'"       = "if"
+convertToJSONName "import'"   = "import"
+convertToJSONName "in'"       = "in"
+convertToJSONName "infix'"    = "infix"
+convertToJSONName "infixl'"   = "infixl"
+convertToJSONName "infixr'"   = "infixr"
+convertToJSONName "instance'" = "instance"
+convertToJSONName "let'"      = "let"
+convertToJSONName "module'"   = "module"
+convertToJSONName "newtype'"  = "newtype"
+convertToJSONName "of'"       = "of"
+convertToJSONName "then'"     = "then"
+convertToJSONName "type'"     = "type"
+convertToJSONName "where'"    = "where"
+convertToJSONName "_'"        = "_"
+convertToJSONName x           = x
 
 convertToHaskellName :: Text -> Text
-convertToHaskellName "type" = "type'"
-convertToHaskellName x      = x
+convertToHaskellName "case"     = "case'"
+convertToHaskellName "class"    = "class'"
+convertToHaskellName "data"     = "data'"
+convertToHaskellName "default"  = "default'"
+convertToHaskellName "deriving" = "deriving'"
+convertToHaskellName "do"       = "do'"
+convertToHaskellName "else"     = "else'"
+convertToHaskellName "foreign"  = "foreign'"
+convertToHaskellName "if"       = "if'"
+convertToHaskellName "import"   = "import'"
+convertToHaskellName "in"       = "in'"
+convertToHaskellName "infix"    = "infix'"
+convertToHaskellName "infixl"   = "infixl'"
+convertToHaskellName "infixr"   = "infixr'"
+convertToHaskellName "instance" = "instance'"
+convertToHaskellName "let"      = "let'"
+convertToHaskellName "module"   = "module'"
+convertToHaskellName "newtype"  = "newtype'"
+convertToHaskellName "of"       = "of'"
+convertToHaskellName "then"     = "then'"
+convertToHaskellName "type"     = "type'"
+convertToHaskellName "where"    = "where'"
+convertToHaskellName "_"        = "_'"
+convertToHaskellName x          = x
 
 -- | Primitive Values for GQLScalar: 'Int', 'Float', 'String', 'Boolean'.
 -- for performance reason type 'Text' represents GraphQl 'String' value


### PR DESCRIPTION
Extend `convertToJSONName` and `convertToHaskellName`  to handle all Haskell 2010 _reservedid_.

A list of reserved keywords in Haskell 2010 can be found [here](https://www.haskell.org/onlinereport/haskell2010/haskellch10.html#TBL-103-3-1). The code preserves the order listed in the original language spec.