### PR TITLE
Change `toGraphQLDocument` to accept `Proxy`

### DIFF
--- a/examples/Main.hs
+++ b/examples/Main.hs
@@ -5,6 +5,7 @@ module Main
   ) where
 
 import           Control.Monad.IO.Class         (liftIO)
+import           Data.Functor.Identity          (Identity(..))
 import           Data.Morpheus                  (Interpreter (..))
 import           Data.Morpheus.Document         (toGraphQLDocument)
 import           Data.Morpheus.Server           (GQLState, gqlSocketApp, initGQLState)
@@ -29,6 +30,6 @@ main = do
       scottyApp $ do
         post "/" $ raw =<< (liftIO . interpreter gqlRoot state =<< body)
         get "/" $ file "examples/index.html"
-        get "/schema.gql" $ raw (toGraphQLDocument gqlRoot)
+        get "/schema.gql" $ raw $ toGraphQLDocument $ Identity gqlRoot
         post "/mythology" $ raw =<< (liftIO . mythologyApi =<< body)
         get "/mythology" $ file "examples/index.html"

--- a/src/Data/Morpheus/Document.hs
+++ b/src/Data/Morpheus/Document.hs
@@ -16,7 +16,7 @@ import           Data.Morpheus.Resolve.Resolve        (RootResCon, fullSchema)
 import           Data.Morpheus.Types                  (GQLRootResolver)
 
 -- | Generates schema.gql file from 'GQLRootResolver'
-toGraphQLDocument :: RootResCon m e c query mut sub => GQLRootResolver m e c query mut sub -> ByteString
+toGraphQLDocument :: RootResCon m e c query mut sub => proxy (GQLRootResolver m e c query mut sub) -> ByteString
 toGraphQLDocument x =
   case fullSchema x of
     Left errors -> pack (show errors)

--- a/src/Data/Morpheus/Resolve/Resolve.hs
+++ b/src/Data/Morpheus/Resolve/Resolve.hs
@@ -21,6 +21,7 @@ import           Data.Aeson.Parser                         (jsonNoDup)
 import           Data.Attoparsec.ByteString                (parseOnly)
 import qualified Data.ByteString                         as S
 import qualified Data.ByteString.Lazy.Char8              as L
+import           Data.Functor.Identity                     (Identity(..))
 import           Data.Proxy
 import           GHC.Generics
 
@@ -89,7 +90,7 @@ streamResolver root@GQLRootResolver {queryResolver, mutationResolver, subscripti
     renderResponse (Right value) = Data value
     ---------------------------------------------------------
     validRequest = do
-      schema <- fullSchema root
+      schema <- fullSchema $ Identity root
       query <- parseGQL request >>= validateRequest schema
       return (schema, query)
     ----------------------------------------------------------
@@ -120,8 +121,8 @@ statefulResolver state streamApi request = do
     execute Subscribe {}      = pure ()
 
 fullSchema ::
-     forall m s cont query mutation subscription. (IntroCon query, IntroCon mutation, IntroCon subscription)
-  => GQLRootResolver m s cont query mutation subscription
+     forall proxy m s cont query mutation subscription . (IntroCon query, IntroCon mutation, IntroCon subscription)
+  => proxy (GQLRootResolver m s cont query mutation subscription)
   -> SchemaValidation DataTypeLib
 fullSchema _ = querySchema >>= mutationSchema >>= subscriptionSchema
   where


### PR DESCRIPTION
For cases where a `GQLRootResolver` may require for example a database
connection.

Don't know if this is preferable or idiomatic, but it helps my particular use case.

Maybe expose another function `toGraphQLDocument . Identity` from `Data.Morpheus.Document`?