### PR TITLE
Fix Graphql typo in README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ extra-deps:
 
 As Morpheus is quite new, make sure stack can find morpheus-graphql by running `stack update`
 
-### Building your first GrqphQL API
+### Building your first GraphQL API
 
 ### with GraphQL syntax
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,7 +39,7 @@ extra-deps:
 
 As Morpheus is quite new, make sure stack can find morpheus-graphql by running `stack update`
 
-### Building your first GrqphQL API
+### Building your first GraphQL API
 
 ### with GraphQL syntax
 


### PR DESCRIPTION
Fixed a small typo in docs (website) and readme 