### PR TITLE
Feature/User can get internal Context of Resolver

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -58,6 +58,16 @@
   }
   ```
 
+- `unsafeInternalContext` to get resolver context, use only if it real necessary.
+  the code depend on it may break even on minor version changing, therefore is called `unsafe`.
+  
+  ```hs
+  resolveUser :: ResolveQ EVENT IO User
+  resolveUser = do
+    Context { currentSelection, schema, operation } <- unsafeInternalContext
+    lift (getDBUser currentSelection)
+  ```
+
 ### Minor
 
 - MonadIO instance for resolvers. Thanks @dandoh

--- a/changelog.md
+++ b/changelog.md
@@ -59,7 +59,7 @@
   ```
 
 - `unsafeInternalContext` to get resolver context, use only if it really necessary.
-  the code depending on it may break even on minor version changes, therefore is called `unsafe`.
+  the code depending on it may break even on minor version changes.
   
   ```hs
   resolveUser :: ResolveQ EVENT IO User

--- a/changelog.md
+++ b/changelog.md
@@ -58,7 +58,7 @@
   }
   ```
 
-- `unsafeInternalContext` to get resolver context, use only if it real necessary.
+- `unsafeInternalContext` to get resolver context, use only if it really necessary.
   the code depend on it may break even on minor version changing, therefore is called `unsafe`.
   
   ```hs

--- a/changelog.md
+++ b/changelog.md
@@ -50,7 +50,7 @@
   `SubField (Resolver Subscription Event IO) User` will generate same as
   `Resolver Subscription Event IO (User ((Resolver QUERY Event IO)))`
   
-  now if you want define subscription with default types as follows
+  now if you want define subscription as follows
   
   ```hs
   data Subscription m = Subscription {

--- a/changelog.md
+++ b/changelog.md
@@ -46,6 +46,18 @@
     where userByEvent (Event _ content) = liftEither (getDBUser content)
   ```
 
+- `type SubField` will convert your subscription monad to query monad.
+  `SubField (Resolver Subscription Event IO) User` will generate same as
+  `Resolver Subscription Event IO (User ((Resolver QUERY Event IO)))`
+  
+  now if you want define subscription with default types as follows
+  
+  ```hs
+  data Subscription m = Subscription {
+    newUser :: SubField m User
+  }
+  ```
+
 ### Minor
 
 - MonadIO instance for resolvers. Thanks @dandoh

--- a/changelog.md
+++ b/changelog.md
@@ -59,7 +59,7 @@
   ```
 
 - `unsafeInternalContext` to get resolver context, use only if it really necessary.
-  the code depend on it may break even on minor version changing, therefore is called `unsafe`.
+  the code depending on it may break even on minor version changes, therefore is called `unsafe`.
   
   ```hs
   resolveUser :: ResolveQ EVENT IO User

--- a/src/Data/Morpheus/Error/Selection.hs
+++ b/src/Data/Morpheus/Error/Selection.hs
@@ -5,7 +5,6 @@ module Data.Morpheus.Error.Selection
   , subfieldsNotSelected
   , duplicateQuerySelections
   , hasNoSubfields
-  , resolvingFailedError
   )
 where
 
@@ -22,13 +21,6 @@ import           Data.Morpheus.Types.Internal.Resolving.Core
 import           Data.Text                      ( Text )
 import qualified Data.Text                     as T
                                                 ( concat )
-
-
-resolvingFailedError :: Position -> Text -> Text -> GQLError
-resolvingFailedError position name reason = GQLError
-  { message   = "Failure on Resolving Field \"" <> name <> "\": " <> reason
-  , locations = [position]
-  }
 
 
 -- GQL: "Field \"default\" must not have a selection since type \"String!\" has no subfields."

--- a/src/Data/Morpheus/Execution/Server/Encode.hs
+++ b/src/Data/Morpheus/Execution/Server/Encode.hs
@@ -157,7 +157,7 @@ convertNode ResNode { resDatatypeName, resKind = REP_UNION, resFields, resTypeNa
 -- Types & Constrains -------------------------------------------------------
 type GQL_RES a = (Generic a, GQLType a)
 
-type EncodeOperation e m a = a -> ValidOperation -> ResponseStream e m ValidValue
+type EncodeOperation e m a = a -> Context -> ResponseStream e m ValidValue
 
 type EncodeCon o e m a = (GQL_RES a, ExploreResolvers (CUSTOM a) a o e m)
 
@@ -212,23 +212,11 @@ encodeSubscription = encodeOperationWith (Proxy @SUBSCRIPTION) Nothing
 encodeOperationWith
   :: forall (o :: OperationType) e m a
    . (Monad m, EncodeCon o e m a, LiftOperation o)
-  => 
-     Proxy o
+  => Proxy o
   -> Maybe (DataResolver o e m)
   -> EncodeOperation e m a
-encodeOperationWith _ externalRes rootResolver Operation { operationSelection ,operationPosition } =
-  runResolver (resolveObject operationSelection (rootDataRes <> extDataRes)) 
-  Context {
-    ctxSelection = (
-      "Root"
-      , Selection {
-        selectionArguments = []
-        , selectionPosition = operationPosition
-        , selectionAlias = Nothing
-        , selectionContent = SelectionSet operationSelection
-      } 
-    )
-  }
+encodeOperationWith _ externalRes rootResolver ctx@Context { operation = Operation { operationSelection } } =
+  runResolver (resolveObject operationSelection (rootDataRes <> extDataRes)) ctx
  where
   rootDataRes = objectResolvers (Proxy :: Proxy (CUSTOM a)) rootResolver
   extDataRes  = fromMaybe (ObjectRes []) externalRes

--- a/src/Data/Morpheus/Execution/Server/Encode.hs
+++ b/src/Data/Morpheus/Execution/Server/Encode.hs
@@ -56,13 +56,10 @@ import           Data.Morpheus.Types.GQLType    ( GQLType(..) )
 import           Data.Morpheus.Types.Internal.AST
                                                 ( Name
                                                 , Operation(..)
-                                                , ValidOperation
                                                 , MUTATION
                                                 , OperationType
                                                 , QUERY
                                                 , SUBSCRIPTION
-                                                , Selection(..)
-                                                , SelectionContent(..)
                                                 , GQLValue(..)
                                                 , ValidValue
                                                 )

--- a/src/Data/Morpheus/Execution/Server/Encode.hs
+++ b/src/Data/Morpheus/Execution/Server/Encode.hs
@@ -79,6 +79,7 @@ import           Data.Morpheus.Types.Internal.Resolving
                                                 , ResponseStream
                                                 , runResolver
                                                 , runDataResolver
+                                                , Context(..)
                                                 )
 
 class Encode resolver o e (m :: * -> *) where
@@ -216,15 +217,18 @@ encodeOperationWith
   -> Maybe (DataResolver o e m)
   -> EncodeOperation e m a
 encodeOperationWith _ externalRes rootResolver Operation { operationSelection ,operationPosition } =
-  runResolver (resolveObject operationSelection (rootDataRes <> extDataRes)) (
-    "Root"
-    , Selection {
+  runResolver (resolveObject operationSelection (rootDataRes <> extDataRes)) 
+  Context {
+    ctxSelection = (
+      "Root"
+      , Selection {
         selectionArguments = []
         , selectionPosition = operationPosition
         , selectionAlias = Nothing
         , selectionContent = SelectionSet operationSelection
-    } 
-  )
+      } 
+    )
+  }
  where
   rootDataRes = objectResolvers (Proxy :: Proxy (CUSTOM a)) rootResolver
   extDataRes  = fromMaybe (ObjectRes []) externalRes

--- a/src/Data/Morpheus/Execution/Server/Encode.hs
+++ b/src/Data/Morpheus/Execution/Server/Encode.hs
@@ -69,7 +69,7 @@ import           Data.Morpheus.Types.Internal.AST
 import           Data.Morpheus.Types.Internal.Resolving
                                                 ( MapStrategy(..)
                                                 , LiftOperation
-                                                , Resolver(..)
+                                                , Resolver
                                                 , unsafeBind
                                                 , toResolver
                                                 , DataResolver(..)

--- a/src/Data/Morpheus/Execution/Server/Resolve.hs
+++ b/src/Data/Morpheus/Execution/Server/Resolve.hs
@@ -73,7 +73,7 @@ import           Data.Morpheus.Types.Internal.AST
                                                 )
 import           Data.Morpheus.Types.Internal.Resolving
                                                 ( GQLRootResolver(..)
-                                                , Resolver(..)
+                                                , Resolver
                                                 , GQLChannel(..)
                                                 , ResponseEvent(..)
                                                 , ResponseStream

--- a/src/Data/Morpheus/Execution/Server/Resolve.hs
+++ b/src/Data/Morpheus/Execution/Server/Resolve.hs
@@ -164,7 +164,7 @@ coreResolver root@GQLRootResolver { queryResolver, mutationResolver, subscriptio
     pure $ Context {
         schema
       , operation
-      , ctxSelection = (
+      , currentSelection = (
         "Root"
         , Selection {
           selectionArguments = []

--- a/src/Data/Morpheus/Schema/SchemaAPI.hs
+++ b/src/Data/Morpheus/Schema/SchemaAPI.hs
@@ -41,7 +41,7 @@ import           Data.Morpheus.Types.Internal.AST
                                                 , lookupDataType
                                                 )
 import           Data.Morpheus.Types.Internal.Resolving
-                                                ( Resolver(..)
+                                                ( Resolver
                                                 , resolveUpdates
                                                 )
 

--- a/src/Data/Morpheus/Types.hs
+++ b/src/Data/Morpheus/Types.hs
@@ -34,6 +34,7 @@ module Data.Morpheus.Types
   , WithOperation
   , publish
   , subscribe
+  , unsafeInternalContext
   )
 where
 
@@ -67,6 +68,7 @@ import           Data.Morpheus.Types.Internal.Resolving
                                                 , pushEvents
                                                 , PushEvents(..)
                                                 , subscribe
+                                                , unsafeInternalContext
                                                 )
 import           Data.Morpheus.Types.IO         ( GQLRequest(..)
                                                 , GQLResponse(..)

--- a/src/Data/Morpheus/Types.hs
+++ b/src/Data/Morpheus/Types.hs
@@ -35,6 +35,7 @@ module Data.Morpheus.Types
   , publish
   , subscribe
   , unsafeInternalContext
+  , SubField
   )
 where
 
@@ -69,6 +70,7 @@ import           Data.Morpheus.Types.Internal.Resolving
                                                 , PushEvents(..)
                                                 , subscribe
                                                 , unsafeInternalContext
+                                                , UnSubResolver
                                                 )
 import           Data.Morpheus.Types.IO         ( GQLRequest(..)
                                                 , GQLResponse(..)
@@ -88,6 +90,8 @@ type ResolveQ e m a = Res e m (a (Res e m))
 type ResolveM e m a = MutRes e m (a (MutRes e m))
 type ResolveS e m a = SubRes e m (a (Res e m))
 
+-- Subsciption Object Resolver Fields
+type SubField m a = (m (a (UnSubResolver m))) 
 
 publish :: Monad m => [e] -> Resolver MUTATION e m ()
 publish = pushEvents

--- a/src/Data/Morpheus/Types/GQLType.hs
+++ b/src/Data/Morpheus/Types/GQLType.hs
@@ -43,7 +43,7 @@ import           Data.Morpheus.Types.Internal.AST.Data
                                                 , QUERY
                                                 )
 import           Data.Morpheus.Types.Internal.Resolving
-                                                ( Resolver(..) )
+                                                ( Resolver )
 
 type TRUE = 'True
 

--- a/src/Data/Morpheus/Types/Internal/Resolving.hs
+++ b/src/Data/Morpheus/Types/Internal/Resolving.hs
@@ -30,7 +30,6 @@ module Data.Morpheus.Types.Internal.Resolving
     , FieldRes
     , WithOperation
     , PushEvents(..)
-    , getContext
     , runDataResolver
     , subscribe
     )

--- a/src/Data/Morpheus/Types/Internal/Resolving.hs
+++ b/src/Data/Morpheus/Types/Internal/Resolving.hs
@@ -33,6 +33,7 @@ module Data.Morpheus.Types.Internal.Resolving
     , runDataResolver
     , subscribe
     , Context(..)
+    , unsafeInternalContext
     )
 where
 

--- a/src/Data/Morpheus/Types/Internal/Resolving.hs
+++ b/src/Data/Morpheus/Types/Internal/Resolving.hs
@@ -32,6 +32,7 @@ module Data.Morpheus.Types.Internal.Resolving
     , PushEvents(..)
     , runDataResolver
     , subscribe
+    , Context(..)
     )
 where
 

--- a/src/Data/Morpheus/Types/Internal/Resolving/Resolver.hs
+++ b/src/Data/Morpheus/Types/Internal/Resolving/Resolver.hs
@@ -64,6 +64,7 @@ import           Data.Morpheus.Types.Internal.AST.Selection
                                                 , ValidSelectionSet
                                                 , ValidSelection
                                                 , ValidArguments
+                                                , ValidOperation
                                                 )
 import           Data.Morpheus.Types.Internal.AST.Base
                                                 ( Message
@@ -75,6 +76,7 @@ import           Data.Morpheus.Types.Internal.AST.Data
                                                 , OperationType
                                                 , QUERY
                                                 , SUBSCRIPTION
+                                                , Schema
                                                 )
 import           Data.Morpheus.Types.Internal.Resolving.Core
                                                 ( GQLErrors
@@ -110,7 +112,9 @@ data ResponseEvent m event
 type SubEvent m event = Event (Channel event) (event -> m GQLResponse)
 
 data Context = Context {
-  ctxSelection :: (Name,ValidSelection)
+  ctxSelection :: (Name,ValidSelection),
+  schema :: Schema,
+  operation :: ValidOperation
 }
 
 -- Resolver Internal State

--- a/src/Data/Morpheus/Types/Internal/Resolving/Resolver.hs
+++ b/src/Data/Morpheus/Types/Internal/Resolving/Resolver.hs
@@ -116,7 +116,7 @@ data Context = Context {
   currentSelection :: (Name,ValidSelection),
   schema :: Schema,
   operation :: ValidOperation
-}
+} deriving (Show)
 
 -- Resolver Internal State
 newtype ResolverState event m a = ResolverState {

--- a/src/Data/Morpheus/Types/Internal/Resolving/Resolver.hs
+++ b/src/Data/Morpheus/Types/Internal/Resolving/Resolver.hs
@@ -275,10 +275,9 @@ subscribe ch res = ResolverS $ do
 unsafeInternalContext :: (Monad m, LiftOperation o) => Resolver o e m Context
 unsafeInternalContext = packResolver $ ResolverState ask 
 
--- Type Helpers  
-type family UnSubResolver (a :: * -> *) :: (* -> *)
-
-type instance UnSubResolver (Resolver SUBSCRIPTION m e) = Resolver QUERY m e
+-- Converts Subscription Resolver Type to Query Resolver
+type family UnSubResolver (a :: * -> * ) :: (* -> *)
+type instance UnSubResolver (Resolver SUBSCRIPTION e m) = Resolver QUERY e m
 
 -- map Resolving strategies 
 class MapStrategy (from :: OperationType) (to :: OperationType) where

--- a/src/Data/Morpheus/Types/Internal/Resolving/Resolver.hs
+++ b/src/Data/Morpheus/Types/Internal/Resolving/Resolver.hs
@@ -112,7 +112,7 @@ data ResponseEvent m event
 type SubEvent m event = Event (Channel event) (event -> m GQLResponse)
 
 data Context = Context {
-  ctxSelection :: (Name,ValidSelection),
+  currentSelection :: (Name,ValidSelection),
   schema :: Schema,
   operation :: ValidOperation
 }
@@ -130,7 +130,7 @@ instance MonadTrans (ResolverState e) where
 
 instance (Monad m) => Failure Message (ResolverState e m) where
   failure message = ResolverState $ do 
-    selection <- ctxSelection <$> ask 
+    selection <- currentSelection <$> ask 
     lift $ failure [resolverFailureMessage selection message]
 
 instance (Monad m) => Failure GQLErrors (ResolverState e m) where
@@ -149,10 +149,10 @@ mapResolverState f (ResolverState x) = ResolverState (f x)
 
 
 getState :: (Monad m) => ResolverState e m (Name,ValidSelection)
-getState = ResolverState $ ctxSelection <$> ask 
+getState = ResolverState $ currentSelection <$> ask 
 
 setState :: (Name,ValidSelection) -> ResolverState e m a -> ResolverState e m a
-setState ctxSelection = mapResolverState (withReaderT (\ctx -> ctx { ctxSelection } ))
+setState currentSelection = mapResolverState (withReaderT (\ctx -> ctx { currentSelection } ))
 
 -- clear evets and starts new resolver with diferenct type of events but with same value
 -- use properly. only if you know what you are doing

--- a/src/Data/Morpheus/Types/Internal/Resolving/Resolver.hs
+++ b/src/Data/Morpheus/Types/Internal/Resolving/Resolver.hs
@@ -40,6 +40,7 @@ module Data.Morpheus.Types.Internal.Resolving.Resolver
   , WithOperation
   , subscribe
   , Context(..)
+  , unsafeInternalContext
   )
 where
 
@@ -270,6 +271,9 @@ subscribe ch res = ResolverS $ do
   pushEvents (map Channel ch :: [Channel e])
   (eventRes :: e -> Resolver QUERY e m a) <- clearStateResolverEvents (runResolverQ res)
   pure $ ReaderT eventRes
+
+unsafeInternalContext :: (Monad m, LiftOperation o) => Resolver o e m Context
+unsafeInternalContext = packResolver $ ResolverState ask 
 
 -- Type Helpers  
 type family UnSubResolver (a :: * -> *) :: (* -> *)

--- a/test/Feature/Holistic/API.hs
+++ b/test/Feature/Holistic/API.hs
@@ -26,7 +26,6 @@ import           Data.Morpheus.Types            ( Event
                                                 , GQLType(..)
                                                 , ID(..)
                                                 , ScalarValue(..)
-                                                , Resolver
                                                 , failRes
                                                 , liftEither
                                                 , subscribe


### PR DESCRIPTION
@smatting  @dandoh  @theobat so, i am not great advocate of sharing internal `AST` (for now it is not stabile yet). but some of you asked it. so exposed `unsafeInternalContext` , the code depend on it may break even on minor version changing,  therefore is called `unsafe` .

another use of this feature can be debugging, you can just print out `AST`, to understand why something does not works.

```hs
data Context = Context {
  currentSelection :: (Name,ValidSelection),
  schema :: Schema,
  operation :: ValidOperation
} deriving (Show)

-- lookup context in Resolver
unsafeInternalContext :: (Monad m, LiftOperation o) => Resolver o e m Context
```

so you can use it as follows:

```hs
resolveUser :: ResolveQ EVENT IO User
resolveUser = do 
  Context { currentSelection, schema, operation } <- unsafeInternalContext
  lift (getDBUser currentSelection)
```

