### PR TITLE
Typo fixes for the schema README example to make it parse correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ type Deity {
   Description for name
   """
   name: String!
-  power: String String! @deprecated(reason: "some reason for")
+  power: String @deprecated(reason: "some reason for")
 }
 ```
 
@@ -76,7 +76,7 @@ import qualified Data.ByteString.Lazy.Char8 as B
 
 import           Data.Morpheus              (interpreter)
 import           Data.Morpheus.Document     (importGQLDocumentWithNamespace)
-import           Data.Morpheus.Types        (GQLRootResolver (..), IORes)
+import           Data.Morpheus.Types        (GQLRootResolver (..), IORes, Undefined(..))
 import           Data.Text                  (Text)
 
 importGQLDocumentWithNamespace "schema.gql"


### PR DESCRIPTION
- The Graphql Schema in the README was not parsing correctly. 
- And the Example could not be find the `Undefined` type and constructor.