### PR TITLE
Prefix enum's data constructors with the type name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,6 +517,13 @@ input Character {
 type Deity {
   name: String!
   worships: Deity
+  power: Power!
+}
+
+enum Power {
+  Lightning
+  Teleportation
+  Omniscience
 }
 ```
 
@@ -534,12 +541,18 @@ data GetHero = GetHero {
 data DeityDeity = DeityDeity {
   name: Text,
   worships: Maybe DeityWorshipsDeity
+  power: Power
 }
 
 -- from: {deity{worships
 data DeityWorshipsDeity = DeityWorshipsDeity {
   name: Text,
 }
+
+data Power =
+    PowerLightning
+  | PowerTeleportation
+  | PowerOmniscience
 
 data GetHeroArgs = GetHeroArgs {
   getHeroArgsCharacter: Character

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.11.0 - Unreleased
+
+### Breaking Changes
+
+- Client generated enum data constructors are now prefixed with with the type name to avoid name conflicts.
+
 ## 0.10.1 - 10.02.2020
 
 ### Added

--- a/docs/index.md
+++ b/docs/index.md
@@ -471,6 +471,13 @@ input Character {
 type Deity {
   name: String!
   worships: Deity
+  power: Power!
+}
+
+enum Power {
+  Lightning
+  Teleportation
+  Omniscience
 }
 ```
 
@@ -488,12 +495,18 @@ data GetHero = GetHero {
 data DeityDeity = DeityDeity {
   name: Text,
   worships: Maybe DeityWorshipsDeity
+  power: Power
 }
 
 -- from: {deity{worships
 data DeityWorshipsDeity = DeityWorshipsDeity {
   name: Text,
 }
+
+data Power =
+    PowerLightning
+  | PowerTeleportation
+  | PowerOmniscience
 
 data GetHeroArgs = GetHeroArgs {
   getHeroArgsCharacter: Character

--- a/examples/src/Client/Client.hs
+++ b/examples/src/Client/Client.hs
@@ -106,7 +106,7 @@ fetchHero = fetch
         { getHeroArgsGod    = Just Realm { realmOwner      = "Zeus"
                                          , realmAge        = Just 10
                                          , realmRealm      = Nothing
-                                         , realmProfession = Just Artist
+                                         , realmProfession = Just ProfessionArtist
                                          }
         , getHeroArgsSomeID = "Hercules"
         }

--- a/src/Data/Morpheus/Execution/Client/Selection.hs
+++ b/src/Data/Morpheus/Execution/Client/Selection.hs
@@ -245,15 +245,15 @@ buildInputType lib name = getType lib name >>= generateTypes
       [ ClientType
           { clientType = TypeD { tName      = typeName
                                , tNamespace = []
-                               , tCons      = map enumOption enumTags
+                               , tCons      = map (enumOption typeName) enumTags
                                , tMeta      = Nothing
                                }
           , clientKind = KindEnum
           }
       ]
      where
-      enumOption DataEnumValue { enumName } =
-        ConsD { cName = enumName, cFields = [] }
+      enumOption typeName' DataEnumValue { enumName } =
+        ConsD { cName = typeName' <> enumName, cFields = [] }
     subTypes _ = pure []
 
 lookupFieldType


### PR DESCRIPTION
Closes #399

@nalchevanidze I tried the change you recommended in the issue, but it seems that change is moving the generated types into different module namespaces. This was breaking the example in `Client.hs` where it could no longer find the generated types. I wasn't sure if you wanted them in different namespaces and.. I wasn't sure how to fix the compilation issues if so.

I figured out this change prefixes the data constructors with the type name.