### PR TITLE
Feature/Tree interface

### DIFF
--- a/morpheus-graphql-core/morpheus-graphql-core.cabal
+++ b/morpheus-graphql-core/morpheus-graphql-core.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 457a9a2576cc71bd505af9cb6e0e0b375b851278a6413907007588a85248509c
+-- hash: 7d8826c6aa0dd87b903df06b422558a14db5d1fe0e3235de2cab115181989a6b
 
 name:           morpheus-graphql-core
 version:        0.11.0
@@ -83,6 +83,7 @@ library
       Data.Morpheus.Types.Internal.Validation
       Data.Morpheus.Types.Internal.Validation.Error
       Data.Morpheus.Types.Internal.Validation.Validator
+      Data.Morpheus.Types.SelectionTree
       Data.Morpheus.Validation.Document.Validation
       Data.Morpheus.Validation.Internal.Value
       Data.Morpheus.Validation.Query.Arguments

--- a/morpheus-graphql-core/src/Data/Morpheus/Core.hs
+++ b/morpheus-graphql-core/src/Data/Morpheus/Core.hs
@@ -20,6 +20,7 @@ module Data.Morpheus.Core
     parseRequestWith,
     parseRequest,
     RenderGQL (..),
+    SelectionTree (..),
   )
 where
 
@@ -67,6 +68,7 @@ import Data.Morpheus.Types.Internal.Resolving
     resultOr,
     runRootResModel,
   )
+import Data.Morpheus.Types.SelectionTree (SelectionTree (..))
 import Data.Morpheus.Validation.Query.Validation
   ( validateRequest,
   )

--- a/morpheus-graphql-core/src/Data/Morpheus/Types/Internal/AST/MergeSet.hs
+++ b/morpheus-graphql-core/src/Data/Morpheus/Types/Internal/AST/MergeSet.hs
@@ -11,6 +11,7 @@ module Data.Morpheus.Types.Internal.AST.MergeSet
     toOrderedMap,
     concatTraverse,
     join,
+    unpack,
   )
 where
 

--- a/morpheus-graphql-core/src/Data/Morpheus/Types/Internal/AST/MergeSet.hs
+++ b/morpheus-graphql-core/src/Data/Morpheus/Types/Internal/AST/MergeSet.hs
@@ -11,7 +11,6 @@ module Data.Morpheus.Types.Internal.AST.MergeSet
     toOrderedMap,
     concatTraverse,
     join,
-    unpack,
   )
 where
 

--- a/morpheus-graphql-core/src/Data/Morpheus/Types/SelectionTree.hs
+++ b/morpheus-graphql-core/src/Data/Morpheus/Types/SelectionTree.hs
@@ -7,7 +7,6 @@
 -- Description : A simple interface for Morpheus internal Selection Set's representation.
 module Data.Morpheus.Types.SelectionTree where
 
-import Data.Maybe (Maybe)
 import Data.Morpheus.Types.Internal.AST.Base (VALID)
 import Data.Morpheus.Types.Internal.AST.MergeSet (unpack)
 import Data.Morpheus.Types.Internal.AST.Selection

--- a/morpheus-graphql-core/src/Data/Morpheus/Types/SelectionTree.hs
+++ b/morpheus-graphql-core/src/Data/Morpheus/Types/SelectionTree.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- |
+-- Module      : Data.Morpheus.Types.SelectionTree
+-- Description : A simple interface for Morpheus internal Selection Set's representation.
+module Data.Morpheus.Types.SelectionTree where
+
+import Data.Maybe (Maybe)
+import Data.Morpheus.Types.Internal.AST.Base (VALID)
+import Data.Morpheus.Types.Internal.AST.MergeSet (unpack)
+import Data.Morpheus.Types.Internal.AST.Selection
+  ( Selection (selectionContent, selectionName),
+    SelectionContent (SelectionField, SelectionSet),
+  )
+import Data.Text (Text)
+
+-- | The 'SelectionTree' instance is a simple interface for interacting
+-- with morpheus's internal AST while keeping the ability to safely change the concrete
+-- representation of the AST.
+-- The set of operation is very limited on purpose.
+class SelectionTree nodeType where
+  -- | leaf test: is the list of children empty?
+  isLeaf :: nodeType -> Bool
+
+  -- | Get the children
+  getChildrenList :: nodeType -> [nodeType]
+
+  -- | get a node's name
+  getName :: nodeType -> Text
+
+instance SelectionTree (Selection VALID) where
+  isLeaf node = case selectionContent node of
+    SelectionField -> True
+    _ -> False
+  getChildrenList node = case selectionContent node of
+    SelectionField -> mempty
+    (SelectionSet deeperSel) -> unpack deeperSel
+  getName = selectionName

--- a/morpheus-graphql-core/src/Data/Morpheus/Types/SelectionTree.hs
+++ b/morpheus-graphql-core/src/Data/Morpheus/Types/SelectionTree.hs
@@ -7,13 +7,12 @@
 -- Description : A simple interface for Morpheus internal Selection Set's representation.
 module Data.Morpheus.Types.SelectionTree where
 
-import Data.Morpheus.Types.Internal.AST.Base (VALID)
-import Data.Morpheus.Types.Internal.AST.MergeSet (unpack)
+import Data.Morpheus.Types.Internal.AST.Base (Name, VALID)
 import Data.Morpheus.Types.Internal.AST.Selection
   ( Selection (selectionContent, selectionName),
     SelectionContent (SelectionField, SelectionSet),
   )
-import Data.Text (Text)
+import Data.Morpheus.Types.Internal.Operation (toList)
 
 -- | The 'SelectionTree' instance is a simple interface for interacting
 -- with morpheus's internal AST while keeping the ability to safely change the concrete
@@ -27,7 +26,7 @@ class SelectionTree nodeType where
   getChildrenList :: nodeType -> [nodeType]
 
   -- | get a node's name
-  getName :: nodeType -> Text
+  getName :: nodeType -> Name
 
 instance SelectionTree (Selection VALID) where
   isLeaf node = case selectionContent node of
@@ -35,5 +34,5 @@ instance SelectionTree (Selection VALID) where
     _ -> False
   getChildrenList node = case selectionContent node of
     SelectionField -> mempty
-    (SelectionSet deeperSel) -> unpack deeperSel
+    (SelectionSet deeperSel) -> toList deeperSel
   getName = selectionName


### PR DESCRIPTION
Following the idea in #348, this enables the manipulation of the ```Selection VALID```exposed in `unsafeInternalContext` (which currently exposes a type unusable for the end user because the constructors/selectors are not exposed).
