### PR TITLE
fix: unexported Context render unsafeInternalContext unusable

### DIFF
--- a/morpheus-graphql-core/src/Data/Morpheus/Types/Internal/Resolving/Resolver.hs
+++ b/morpheus-graphql-core/src/Data/Morpheus/Types/Internal/Resolving/Resolver.hs
@@ -128,6 +128,7 @@ data ResponseEvent event (m :: * -> *)
 
 type SubEvent event m = Event (Channel event) (event -> m GQLResponse)
 
+-- | A datatype to expose 'Schema' and the query's AST information ('Selection', 'Operation').
 data Context = Context
   { currentSelection :: Selection VALID,
     schema :: Schema,
@@ -325,6 +326,10 @@ subscribe ch res = ResolverS $ do
   (eventRes :: e -> Resolver QUERY e m a) <- clearStateResolverEvents (runResolverQ res)
   pure $ ReaderT eventRes
 
+-- | A function to return the internal 'Context' within a resolver's monad.
+-- Using the 'Context' itself is unsafe because it expposes internal structures
+-- of the AST, but you can use the "Data.Morpheus.Types.SelectionTree" typeclass to manipulate
+-- the internal AST with a safe interface.
 unsafeInternalContext :: (Monad m, LiftOperation o) => Resolver o e m Context
 unsafeInternalContext = packResolver $ ResolverState ask
 

--- a/src/Data/Morpheus/Types.hs
+++ b/src/Data/Morpheus/Types.hs
@@ -31,6 +31,7 @@ module Data.Morpheus.Types
     publish,
     subscribe,
     unsafeInternalContext,
+    Context (..),
     SubField,
     ComposedSubField,
     Input,
@@ -85,7 +86,8 @@ import Data.Morpheus.Types.Internal.AST
     TypeUpdater,
   )
 import Data.Morpheus.Types.Internal.Resolving
-  ( Event (..),
+  ( Context (..),
+    Event (..),
     Failure,
     PushEvents (..),
     Resolver,


### PR DESCRIPTION
This PR is meant to fix the absence of the Context datatype in Data.Morpheus.Types
Importing the context directly from the morpheus-graphql-core module creates mismatch between other types afterwards (Resolver, etc...). So this is required in order to access `currentSelection` within the Context