### PR TITLE
change types String to FilePath

### DIFF
--- a/morpheus-graphql-client/src/Data/Morpheus/Client.hs
+++ b/morpheus-graphql-client/src/Data/Morpheus/Client.hs
@@ -46,10 +46,10 @@ import Data.Morpheus.Types.Internal.Resolving
   )
 import Language.Haskell.TH
 
-defineByDocumentFile :: String -> (GQLQuery, String) -> Q [Dec]
+defineByDocumentFile :: FilePath -> (GQLQuery, String) -> Q [Dec]
 defineByDocumentFile = defineByDocument . L.readFile
 
-defineByIntrospectionFile :: String -> (GQLQuery, String) -> Q [Dec]
+defineByIntrospectionFile :: FilePath -> (GQLQuery, String) -> Q [Dec]
 defineByIntrospectionFile = defineByIntrospection . L.readFile
 
 defineByDocument :: IO ByteString -> (GQLQuery, String) -> Q [Dec]

--- a/src/Data/Morpheus/Document.hs
+++ b/src/Data/Morpheus/Document.hs
@@ -37,7 +37,7 @@ import qualified Data.Text.Lazy as LT
 import Data.Text.Lazy.Encoding (encodeUtf8)
 import Language.Haskell.TH
 
-importGQLDocument :: String -> Q [Dec]
+importGQLDocument :: FilePath -> Q [Dec]
 importGQLDocument src =
   runIO (readFile src)
     >>= compileDocument
@@ -45,7 +45,7 @@ importGQLDocument src =
         { namespace = False
         }
 
-importGQLDocumentWithNamespace :: String -> Q [Dec]
+importGQLDocumentWithNamespace :: FilePath -> Q [Dec]
 importGQLDocumentWithNamespace src =
   runIO (readFile src)
     >>= compileDocument


### PR DESCRIPTION
Changed `defineByDocumentFile`, `defineByIntrospectionFile`,
`importGQLDocument`, `importGQLDocumentWithNamespace`, to take the type
synonym FilePath instead of String.

r/t https://github.com/morpheusgraphql/morpheus-graphql/issues/518