### PR TITLE
Export all methods for the GQLType class

### DIFF
--- a/src/Data/Morpheus/Types.hs
+++ b/src/Data/Morpheus/Types.hs
@@ -11,7 +11,7 @@
 -- | GQL Types
 module Data.Morpheus.Types
   ( Event (..),
-    GQLType (KIND, description, implements),
+    GQLType (KIND, description, implements, getDescriptions, typeOptions, getDirectives),
     GQLScalar (parseValue, serialize),
     GQLRequest (..),
     GQLResponse (..),


### PR DESCRIPTION
Hello!

I noticed that release 0.15.0 says

> GQLType exposes typeOptions to modify labels: typeOptions :: f a -> GQLTypeOptions

But I could not use it as it does not seem to be exposed. At least not when importing `Data.Morpheus.Types`. The haddock seems to confirm this as it only shows the methods `description` and `implements`: http://hackage.haskell.org/package/morpheus-graphql-0.15.0/docs/Data-Morpheus-Types.html

This PR should export all the methods, but perhaps it's overkill and more than desired. Happy to make any changes.

Thank you!