### PR TITLE
Example of using fraxl library for request batching

### DIFF
--- a/morpheus-graphql-examples-scotty/morpheus-graphql-examples-scotty.cabal
+++ b/morpheus-graphql-examples-scotty/morpheus-graphql-examples-scotty.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 70ec259bc06acc24fdfc254b94c83ae3922452dbbadf6c1378e832e742f83459
+-- hash: 399c1857bdd307f1c12dfe7f81269f2e5c486088bff8887cf59aff4fbba42598
 
 name:           morpheus-graphql-examples-scotty
 version:        0.1.0
@@ -32,6 +32,8 @@ executable scotty-server
   other-modules:
       Client.Client
       Files
+      Server.Fraxl.API
+      Server.Fraxl.FakeDB
       Server.MonadIO.API
       Server.Mythology.API
       Server.Mythology.Character
@@ -51,6 +53,7 @@ executable scotty-server
     , bytestring >=0.10.4 && <0.11
     , containers >=0.4.2.1 && <0.7
     , extra
+    , fraxl
     , http-types
     , morpheus-graphql >=0.15.0
     , morpheus-graphql-client >=0.15.0

--- a/morpheus-graphql-examples-scotty/package.yaml
+++ b/morpheus-graphql-examples-scotty/package.yaml
@@ -28,6 +28,7 @@ dependencies:
   - extra
   - http-types
   - stm
+  - fraxl
 
 data-files:
   - assets/**/*.json

--- a/morpheus-graphql-examples-scotty/src/Server/Fraxl/API.hs
+++ b/morpheus-graphql-examples-scotty/src/Server/Fraxl/API.hs
@@ -46,6 +46,21 @@ import Web.Scotty
     raw,
   )
 
+-- This file contains an example of how to use the `fraxl` library to address
+-- the N+1 queries problem, a common problem with implementing GraphQL APIs.
+--
+-- We'll explain this problem more as we go, but first, let's define our GraphQL
+-- API - here we have a database of bands, musicians, and instruments.  For the
+-- purposes of this example, each band member is a member of a single band and
+-- plays a single instrument.  The user can query for a list of all instruments
+-- in the database.
+
+newtype Query m
+  = Query
+      { instruments :: m [Instrument m]
+      }
+  deriving (Generic, GQLType)
+
 data Instrument m
   = Instrument
       { name :: Text,
@@ -67,11 +82,33 @@ data Band m
       }
   deriving (Generic, GQLType)
 
+-- Now, imagine we have a database structure with an `instrument` table, a
+-- `band_memmber` table, and a `band` table.
+--
+-- To query all instruments, we would need to do a SELECT on the `instrument`
+-- table.  If the graphql client asks for the `players` field of our
+-- `Instrument` graphql type, we'll also have to get the band members associated
+-- with each instrument.
+--
+-- One way to implement this would be to make a separate SELECT on the
+-- `band_member` table for each instrument ID we receive from our initial SELECT
+-- on the `instrument` table.  However, this will have bad performance with a
+-- large number of instruments, since we'll have to send many queries to the
+-- database.  This is a prototypical example of the N+1 queries problem.  While
+-- there are many ways to achieve good performance, such as pre-fetching, the
+-- `fraxl` library provides a particularly elegant solution to this issue.
+--
+-- To use `fraxl`, first we have to define a `Source` GADT that represents all
+-- the different (unbatched) queries we can make to the database.
+
 data Source a where
   GetInstruments :: Source [DB.Instrument]
   GetBandMemberByInstrumentID :: Int -> Source [DB.Member]
   GetBandMemberByBandID :: Int -> Source [DB.Member]
   GetBandByID :: Int -> Source DB.Band
+
+-- Now, we define a type that represents a "batched" request, containing
+-- potentially multiple different queries.
 
 data BatchedReq
   = BatchedReq
@@ -80,12 +117,8 @@ data BatchedReq
         bandIDs :: Set Int
       }
 
-data BatchedRes
-  = BatchedRes
-      { memberByInstrumentIDs :: Map Int [DB.Member],
-        memberByBandIDs :: Map Int [DB.Member],
-        bands :: Map Int DB.Band
-      }
+-- Then, we define how to combine many `Source a` into a single `BatchedReq`.
+-- Here `ASeq` is a heterogenous list type over `Source`.
 
 batchSource :: ASeq Source a -> BatchedReq
 batchSource = flip execState (BatchedReq mempty mempty mempty) . traverseASeq batch
@@ -96,12 +129,27 @@ batchSource = flip execState (BatchedReq mempty mempty mempty) . traverseASeq ba
     batch x@(GetBandByID y) = modify (\b -> b {bandIDs = singleton y <> bandIDs b}) >> pure x
     batch x = pure x
 
+-- Next, we define a result of the batched request.
+
+data BatchedRes
+  = BatchedRes
+      { memberByInstrumentIDs :: Map Int [DB.Member],
+        memberByBandIDs :: Map Int [DB.Member],
+        bands :: Map Int DB.Band
+      }
+
+-- And, how to run the batched request to get a batched result - here `DB.Query`
+-- is a monad that tracks the effect of accessing the database.
+
 runBatch :: BatchedReq -> DB.Query BatchedRes
 runBatch BatchedReq {memberInstrumentIDs, memberBandIDs, bandIDs} =
   BatchedRes
     <$> DB.getBandMembersByInstrumentID memberInstrumentIDs
     <*> DB.getBandMembersByBandID memberBandIDs
     <*> DB.getBandsByID bandIDs
+
+-- This, `doFetch` helper actually provides the value for each `Source a`, while
+-- reading from a `BatchedRes` result.
 
 doFetch :: Source a -> Reader BatchedRes (DB.Query a)
 doFetch GetInstruments = pure DB.getInstruments
@@ -112,14 +160,21 @@ doFetch (GetBandMemberByBandID i) =
 doFetch (GetBandByID i) =
   asks (pure . fromJust . Data.Map.lookup i . bands)
 
+-- We bundle these helpers together into a `fraxl` `Fetch`, which
+-- interprets an `ASeq` of `Source a`s under the `DB.Query` monad.  This is
+-- where the power of fraxl lies - while handling a GraphQL request, this
+-- `fetch` will be invoked multiple times, each time with a collection of
+-- `Source a` requests that do not depend on eachother. This allows us to use
+-- `batchSource` to combine a large number of `Source`s into a single database query.
+--
+-- For more on how this works, see the `fraxl` documentation or documentation on
+-- `Haxl`, the library that inspired fraxl.
+
 fetchSource :: Fetch Source DB.Query a
 fetchSource as = runReader (traverseASeq doFetch as) <$> runBatch (batchSource as)
 
-newtype Query m
-  = Query
-      { instruments :: m [Instrument m]
-      }
-  deriving (Generic, GQLType)
+-- Now, we write our QraphQL resolvers, using `fraxl`'s `dataFetch` with one of
+-- our `Source` constructors whenever we need to access the DB.
 
 resolveBand ::
   (Monad (t (FreerT Source m)), MonadTrans t, Monad m) =>
@@ -167,6 +222,8 @@ rootResolver =
 
 app :: App () (FreerT Source DB.Query)
 app = deriveApp rootResolver
+
+-- Finally, we can `runFraxl` with our `fetchSource` fetcher.
 
 httpEndpoint ::
   RoutePattern ->

--- a/morpheus-graphql-examples-scotty/src/Server/Fraxl/API.hs
+++ b/morpheus-graphql-examples-scotty/src/Server/Fraxl/API.hs
@@ -1,0 +1,177 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Server.Fraxl.API
+  ( httpEndpoint,
+  )
+where
+
+import Control.Applicative ((<|>))
+import Control.Monad.Fraxl (ASeq (..), Fetch, FreerT, dataFetch, runFraxl, traverseASeq)
+import Control.Monad.Reader (Reader, ask, runReader)
+import Control.Monad.State (State, execState, modify)
+import Control.Monad.Trans (MonadTrans, lift)
+import Data.Map (Map, lookup)
+import Data.Maybe (fromJust)
+import Data.Monoid ((<>))
+import Data.Morpheus
+  ( App,
+    deriveApp,
+    runApp,
+  )
+import Data.Morpheus.Server
+  ( httpPlayground,
+  )
+import Data.Morpheus.Types
+  ( GQLType,
+    RootResolver (..),
+    Undefined (..),
+    render,
+  )
+import Data.Set (Set, singleton)
+import Data.Text (Text)
+import GHC.Generics (Generic)
+import qualified Server.Fraxl.FakeDB as DB
+import Server.Utils (isSchema)
+import Web.Scotty
+  ( RoutePattern,
+    ScottyM,
+    body,
+    get,
+    post,
+    raw,
+  )
+
+data Instrument m
+  = Instrument
+      { name :: Text,
+        players :: m [BandMember m]
+      }
+  deriving (Generic, GQLType)
+
+data BandMember m
+  = BandMember
+      { name :: Text,
+        band :: m (Band m)
+      }
+  deriving (Generic, GQLType)
+
+data Band m
+  = Band
+      { name :: Text,
+        members :: m [BandMember m]
+      }
+  deriving (Generic, GQLType)
+
+data Source a where
+  GetInstruments :: Source [DB.Instrument]
+  GetBandMemberByInstrumentID :: Int -> Source [DB.Member]
+  GetBandMemberByBandID :: Int -> Source [DB.Member]
+  GetBandByID :: Int -> Source DB.Band
+
+data BatchedReq
+  = BatchedReq
+      { memberInstrumentIDs :: Set Int,
+        memberBandIDs :: Set Int,
+        bandIDs :: Set Int
+      }
+
+data BatchedRes
+  = BatchedRes
+      { memberByInstrumentIDs :: Map Int [DB.Member],
+        memberByBandIDs :: Map Int [DB.Member],
+        bands :: Map Int DB.Band
+      }
+
+batchSource :: ASeq Source a -> BatchedReq
+batchSource = flip execState (BatchedReq mempty mempty mempty) . traverseASeq batch
+  where
+    batch :: Source a -> State BatchedReq (Source a)
+    batch x@(GetBandMemberByInstrumentID y) = modify (\b -> b {memberInstrumentIDs = (singleton y) <> memberInstrumentIDs b}) >> pure x
+    batch x@(GetBandMemberByBandID y) = modify (\b -> b {memberBandIDs = (singleton y) <> memberBandIDs b}) >> pure x
+    batch x@(GetBandByID y) = modify (\b -> b {bandIDs = (singleton y) <> bandIDs b}) >> pure x
+    batch x = pure x
+
+runBatch :: BatchedReq -> DB.Query BatchedRes
+runBatch BatchedReq {memberInstrumentIDs, memberBandIDs, bandIDs} =
+  BatchedRes
+    <$> DB.getBandMembersByInstrumentID memberInstrumentIDs
+    <*> DB.getBandMembersByBandID memberBandIDs
+    <*> DB.getBandsByID bandIDs
+
+doFetch :: Source a -> Reader BatchedRes (DB.Query a)
+doFetch GetInstruments = pure $ DB.getInstruments
+doFetch (GetBandMemberByInstrumentID i) =
+  (pure . fromJust . Data.Map.lookup i . memberByInstrumentIDs) <$> ask
+doFetch (GetBandMemberByBandID i) =
+  (pure . fromJust . Data.Map.lookup i . memberByBandIDs) <$> ask
+doFetch (GetBandByID i) = (pure . fromJust . Data.Map.lookup i . bands) <$> ask
+
+fetchSource :: Fetch Source DB.Query a
+fetchSource as = runReader (traverseASeq doFetch as) <$> runBatch (batchSource as)
+
+data Query m
+  = Query
+      { instruments :: m [Instrument m]
+      }
+  deriving (Generic, GQLType)
+
+resolveBand ::
+  (Monad (t (FreerT Source m)), MonadTrans t, Monad m) =>
+  DB.Band ->
+  t (FreerT Source m) (Band (t (FreerT Source m)))
+resolveBand DB.Band {name, id = i} =
+  pure
+    Band
+      { name,
+        members = lift (dataFetch $ GetBandMemberByBandID i) >>= sequenceA . (resolveBandMember <$>)
+      }
+
+resolveBandMember ::
+  (Monad (t (FreerT Source m)), MonadTrans t, Monad m) =>
+  DB.Member ->
+  t (FreerT Source m) (BandMember (t (FreerT Source m)))
+resolveBandMember DB.Member {name, bandID} =
+  pure
+    BandMember
+      { name,
+        band = lift (dataFetch $ GetBandByID bandID) >>= resolveBand
+      }
+
+resolveInstrument ::
+  (Monad (t (FreerT Source m)), MonadTrans t, Monad m) =>
+  DB.Instrument ->
+  t (FreerT Source m) (Instrument (t (FreerT Source m)))
+resolveInstrument DB.Instrument {name, id = i} =
+  pure
+    Instrument
+      { name,
+        players = lift (dataFetch $ GetBandMemberByInstrumentID i) >>= sequenceA . (resolveBandMember <$>)
+      }
+
+resolveInstruments :: (Monad (t (FreerT Source m)), MonadTrans t, Monad m) => t (FreerT Source m) [Instrument (t (FreerT Source m))]
+resolveInstruments = lift (dataFetch GetInstruments) >>= sequenceA . (resolveInstrument <$>)
+
+rootResolver :: (Monad m) => RootResolver (FreerT Source m) () Query Undefined Undefined
+rootResolver =
+  RootResolver
+    { queryResolver = Query {instruments = resolveInstruments},
+      mutationResolver = Undefined,
+      subscriptionResolver = Undefined
+    }
+
+app :: App () (FreerT Source DB.Query)
+app = deriveApp rootResolver
+
+httpEndpoint ::
+  RoutePattern ->
+  ScottyM ()
+httpEndpoint route = do
+  get route $
+    (isSchema *> raw (render app))
+      <|> raw httpPlayground
+  post route $ raw =<< ((pure . DB.runQuery . runFraxl fetchSource . runApp app) =<< body)

--- a/morpheus-graphql-examples-scotty/src/Server/Fraxl/FakeDB.hs
+++ b/morpheus-graphql-examples-scotty/src/Server/Fraxl/FakeDB.hs
@@ -1,0 +1,93 @@
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Server.Fraxl.FakeDB
+  ( Band (..),
+    Member (..),
+    Instrument (..),
+    Query,
+    runQuery,
+    getInstruments,
+    getBandMembersByInstrumentID,
+    getBandMembersByBandID,
+    getBandsByID,
+  )
+where
+
+import Data.Foldable (fold)
+import Data.Functor.Identity (Identity (..), runIdentity)
+import qualified Data.Map as M
+import Data.Map (Map)
+import Data.Set (Set, toList)
+import Data.Text (Text)
+
+data Band
+  = Band
+      { name :: Text,
+        id :: Int
+      }
+
+bandDB :: [Band]
+bandDB =
+  [ Band "Jem and the Holograms" 0,
+    Band "The Misfits" 1
+  ]
+
+data Member
+  = Member
+      { name :: Text,
+        instrumentID :: Int,
+        bandID :: Int
+      }
+
+memberDB :: [Member]
+memberDB =
+  [ Member "Jerrica" 0 0,
+    Member "Kimber" 1 0,
+    Member "Aja" 2 0,
+    Member "Shana" 3 0,
+    Member "Carmen" 4 0,
+    Member "Glenn" 0 1,
+    Member "Franché" 2 1,
+    Member "Jerry" 3 1,
+    Member "Jim" 4 1
+  ]
+
+data Instrument
+  = Instrument
+      { name :: Text,
+        id :: Int
+      }
+
+instrumentDB :: [Instrument]
+instrumentDB =
+  [ Instrument "Vocals" 0,
+    Instrument "Synthesizer" 1,
+    Instrument "Guitar" 2,
+    Instrument "Bass Guitar" 3,
+    Instrument "Drums" 4
+  ]
+
+newtype Query a = Query (Identity a) deriving (Functor, Applicative, Monad)
+
+runQuery :: Query a -> a
+runQuery (Query a) = runIdentity a
+
+getInstruments :: Query [Instrument]
+getInstruments = pure instrumentDB
+
+lookupOneToMany :: (Ord b) => (a -> b) -> [a] -> Set b -> Map b [a]
+lookupOneToMany x ys xs = fold (((\x' -> M.singleton x' (filter (\y -> x y == x') ys))) <$> toList xs)
+
+lookupOneToOne :: (Ord b) => (a -> b) -> [a] -> Set b -> Map b a
+lookupOneToOne x ys xs = fold (((\y -> M.singleton (x y) y)) <$> filter (\y -> x y `elem` xs) ys)
+
+getBandMembersByInstrumentID :: Set Int -> Query (Map Int [Member])
+getBandMembersByInstrumentID = pure . (lookupOneToMany instrumentID memberDB)
+
+getBandMembersByBandID :: Set Int -> Query (Map Int [Member])
+getBandMembersByBandID = pure . (lookupOneToMany bandID memberDB)
+
+getBandsByID :: Set Int -> Query (Map Int Band)
+getBandsByID = pure . (lookupOneToOne (\Band {id = i} -> i) bandDB)

--- a/morpheus-graphql-examples-scotty/src/Server/Fraxl/FakeDB.hs
+++ b/morpheus-graphql-examples-scotty/src/Server/Fraxl/FakeDB.hs
@@ -78,16 +78,16 @@ getInstruments :: Query [Instrument]
 getInstruments = pure instrumentDB
 
 lookupOneToMany :: (Ord b) => (a -> b) -> [a] -> Set b -> Map b [a]
-lookupOneToMany x ys xs = fold (((\x' -> M.singleton x' (filter (\y -> x y == x') ys))) <$> toList xs)
+lookupOneToMany x ys xs = fold ((\x' -> M.singleton x' (filter (\y -> x y == x') ys)) <$> toList xs)
 
 lookupOneToOne :: (Ord b) => (a -> b) -> [a] -> Set b -> Map b a
-lookupOneToOne x ys xs = fold (((\y -> M.singleton (x y) y)) <$> filter (\y -> x y `elem` xs) ys)
+lookupOneToOne x ys xs = fold ((\y -> M.singleton (x y) y) <$> filter (\y -> x y `elem` xs) ys)
 
 getBandMembersByInstrumentID :: Set Int -> Query (Map Int [Member])
-getBandMembersByInstrumentID = pure . (lookupOneToMany instrumentID memberDB)
+getBandMembersByInstrumentID = pure . lookupOneToMany instrumentID memberDB
 
 getBandMembersByBandID :: Set Int -> Query (Map Int [Member])
-getBandMembersByBandID = pure . (lookupOneToMany bandID memberDB)
+getBandMembersByBandID = pure . lookupOneToMany bandID memberDB
 
 getBandsByID :: Set Int -> Query (Map Int Band)
-getBandsByID = pure . (lookupOneToOne (\Band {id = i} -> i) bandDB)
+getBandsByID = pure . lookupOneToOne (\Band {id = i} -> i) bandDB

--- a/morpheus-graphql-examples-scotty/src/Server/Scotty.hs
+++ b/morpheus-graphql-examples-scotty/src/Server/Scotty.hs
@@ -19,6 +19,7 @@ import Data.Morpheus.Server
   ( compileTimeSchemaValidation,
     webSocketsApp,
   )
+import qualified Server.Fraxl.API as Fraxl
 import qualified Server.Mythology.API as Mythology
 import Server.Sophisticated.API
   ( EVENT,
@@ -47,4 +48,5 @@ scottyServer = do
     httpApp publish = do
       httpEndpoint "/" [publish] app
       httpEndpoint "/mythology" [] Mythology.app
+      Fraxl.httpEndpoint "/fraxl"
       httpEndpoint "/th" [] TH.app

--- a/morpheus-graphql-examples-scotty/src/Server/Utils.hs
+++ b/morpheus-graphql-examples-scotty/src/Server/Utils.hs
@@ -7,6 +7,7 @@
 module Server.Utils
   ( httpEndpoint,
     startServer,
+    isSchema,
   )
 where
 

--- a/stack-11.10.yaml
+++ b/stack-11.10.yaml
@@ -20,3 +20,8 @@ extra-deps:
   - modern-uri-0.3.0.0
   - retry-0.8.1.0
   - relude-0.3.0
+  - fraxl-0.3.0.0
+  - dependent-map-0.2.4.0
+  - dependent-sum-0.4
+  - fastsum-0.1.0.0
+  - type-aligned-0.9.6

--- a/stack-12.16.yaml
+++ b/stack-12.16.yaml
@@ -18,3 +18,8 @@ extra-deps:
   - modern-uri-0.3.0.0
   - retry-0.8.1.0
   - relude-0.3.0
+  - fraxl-0.3.0.0
+  - dependent-map-0.2.4.0
+  - dependent-sum-0.4
+  - fastsum-0.1.0.0
+  - type-aligned-0.9.6

--- a/stack-14.14.yaml
+++ b/stack-14.14.yaml
@@ -8,3 +8,10 @@ packages:
   - morpheus-graphql-client
   - morpheus-graphql-core
   - .
+
+extra-deps:
+  - fraxl-0.3.0.0
+  - dependent-map-0.2.4.0
+  - dependent-sum-0.4
+  - fastsum-0.1.1.1
+  - type-aligned-0.9.6

--- a/stack-15.3.yaml
+++ b/stack-15.3.yaml
@@ -8,3 +8,10 @@ packages:
   - morpheus-graphql-client
   - morpheus-graphql-core
   - .
+
+extra-deps:
+  - fraxl-0.3.0.0
+  - dependent-map-0.2.4.0
+  - dependent-sum-0.4
+  - fastsum-0.1.1.1
+  - type-aligned-0.9.6

--- a/stack-16.2.yaml
+++ b/stack-16.2.yaml
@@ -8,3 +8,10 @@ packages:
   - morpheus-graphql-client
   - morpheus-graphql-core
   - .
+
+extra-deps:
+  - fraxl-0.3.0.0
+  - dependent-map-0.2.4.0
+  - dependent-sum-0.4
+  - fastsum-0.1.1.1
+  - type-aligned-0.9.6

--- a/stack.yaml
+++ b/stack.yaml
@@ -13,3 +13,8 @@ allow-newer: true
 extra-deps:
   - servant-server-0.16.2
   - servant-0.16.2
+  - fraxl-0.3.0.0
+  - dependent-map-0.2.4.0
+  - dependent-sum-0.4
+  - fastsum-0.1.1.1
+  - type-aligned-0.9.6


### PR DESCRIPTION
This is an example of using fraxl to batch database requests, which prevents the N+1 queries problem.  Related to the conversation in #348 

Probably a lot of room for improvement here - eagerly awaiting feedback/corrections