### PR TITLE
rebuild when the schema changes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## (next version)
+
+- more likely to rebuild when a file loaded by `importGQLDocument` or
+  `importGQLDocumentWithNamespace` is changed
+
 ## 0.16.0 - 05.11.2020
 
 ## Breaking changes

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ## (next version)
 
+### Minor Changes
+
 - more likely to rebuild when a file loaded by `importGQLDocument` or
   `importGQLDocumentWithNamespace` is changed
 

--- a/morpheus-graphql-client/changelog.md
+++ b/morpheus-graphql-client/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## (next version)
+
+### Minor Changes
+
+- more likely to rebuild when a file loaded by `defineByDocumentFile` or
+  `defineByIntrospectionFile` is changed
+
 ## 0.16.0 - 05.11.2020
 
 ### Minor Changes

--- a/morpheus-graphql-client/src/Data/Morpheus/Client.hs
+++ b/morpheus-graphql-client/src/Data/Morpheus/Client.hs
@@ -44,13 +44,20 @@ import Data.Morpheus.Types.Internal.Resolving
   ( Eventless,
   )
 import Language.Haskell.TH
+import Language.Haskell.TH.Syntax
+  ( qAddDependentFile,
+  )
 import Relude hiding (ByteString)
 
 defineByDocumentFile :: FilePath -> (GQLQuery, String) -> Q [Dec]
-defineByDocumentFile = defineByDocument . L.readFile
+defineByDocumentFile filePath args = do
+  qAddDependentFile filePath
+  defineByDocument (L.readFile filePath) args
 
 defineByIntrospectionFile :: FilePath -> (GQLQuery, String) -> Q [Dec]
-defineByIntrospectionFile = defineByIntrospection . L.readFile
+defineByIntrospectionFile filePath args = do
+  qAddDependentFile filePath
+  defineByIntrospection (L.readFile filePath) args
 
 defineByDocument :: IO ByteString -> (GQLQuery, String) -> Q [Dec]
 defineByDocument doc = defineQuery (schemaByDocument doc)

--- a/src/Data/Morpheus/Document.hs
+++ b/src/Data/Morpheus/Document.hs
@@ -33,10 +33,14 @@ import Data.Morpheus.Types.Internal.Resolving
   ( resultOr,
   )
 import Language.Haskell.TH
+import Language.Haskell.TH.Syntax
+  ( qAddDependentFile,
+  )
 import Relude hiding (ByteString)
 
 importGQLDocument :: FilePath -> Q [Dec]
-importGQLDocument src =
+importGQLDocument src = do
+  qAddDependentFile src
   runIO (readFile src)
     >>= compileDocument
       ServerDecContext
@@ -44,7 +48,8 @@ importGQLDocument src =
         }
 
 importGQLDocumentWithNamespace :: FilePath -> Q [Dec]
-importGQLDocumentWithNamespace src =
+importGQLDocumentWithNamespace src = do
+  qAddDependentFile src
   runIO (readFile src)
     >>= compileDocument
       ServerDecContext


### PR DESCRIPTION
It is important to always call `qAddDependentFile` before reading a file in TH, as it allows allows GHC to decide whether to rebuild a module or not. Without `qAddDependentFile`, GHC will not rebuild the module if the file TH read has changed but the module file has not. With `qAddDependentFile`, GHC will rebuild the module if either file changed.

This is especially maddening if the code which loads the schema file and the resolvers are in a different modules. If I modify the name of something in the schema file and I modify the resolvers to match, I will get a compilation error telling me that the new names are not valid, and that I should be using the old names! The workaround is to make a dummy whitespace change to the module which loads the schema, thus forcing GHC to rebuild that module.

Adding `qAddDependentFile` is required, but unfortunately not sufficient. If you only modify the schema file and then rebuild in order to see what are all the resolvers which now need to be updated, stack and cabal both erroneously think that nothing needs to be rebuilt since none of the _Haskell_ files have been modified. I don't know what is the proper way to address that part of the problem: I have tried to add the schema file to either the `extra-source-files` or the `data-files` section of the cabal file, to no avail.