### PR TITLE
Add typeNameModifier to GQLTypeOptions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,7 +18,7 @@
   }
   deriving (Show, Generic)
 
-  deityTypeNameModifier isInput original =
+  deityTypeNameModifier isInput original
     | isInput = "Input" ++ original
     | otherwise = original
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,11 +1,13 @@
 # Changelog
 
-## 0.17.0 - 05.11.2020
+## 0.17.0 - Unreleased
 
 ## new features
 
-- (issue #543): `GQLTypeOptions` supports new option `prefixInputType`.
-  before the schema failed if you wanted to use the same type for input and output, but now with this option you can automatically prefix the input with a "Input" to make this possible.
+- (issue [#543](https://github.com/morpheusgraphql/morpheus-graphql/issues/543) & [#558](https://github.com/morpheusgraphql/morpheus-graphql/issues/558)): `GQLTypeOptions` supports new option `typeNameModifier`.
+  Before the schema failed if you wanted to use the same type for input and output, and the user had no control over the eventual GraphQL type name of the generated schema. Now with this option you can
+  provide a function of type `Bool -> String -> String` that generates a custom GraphQL type name. The first argument is a `Bool` that is `True` if the type is an input, and `False` otherwise. The second
+  argument is a `String` representing the initial, auto-generated GraphQL type name. The function returns the desired type name.
 
   e.g this schema will not fail. morpheus will generate types: `Deity` and `InputDeity`
 
@@ -16,8 +18,11 @@
   }
   deriving (Show, Generic)
 
+  deityTypeNameModifier True original = "Input" ++ original
+  deityTypeNameModifier False original = "Output" ++ original
+
   instance GQLType Deity where
-    typeOptions _ opt = opt {prefixInputType = True}
+    typeOptions _ opt = opt {typeNameModifier = deityTypeNameModifier}
 
   newtype DeityArgs = DeityArgs
     { input :: Deity

--- a/changelog.md
+++ b/changelog.md
@@ -7,7 +7,7 @@
 - (issue [#543](https://github.com/morpheusgraphql/morpheus-graphql/issues/543) & [#558](https://github.com/morpheusgraphql/morpheus-graphql/issues/558)): `GQLTypeOptions` supports new option `typeNameModifier`.
   Before the schema failed if you wanted to use the same type for input and output, and the user had no control over the eventual GraphQL type name of the generated schema. Now with this option you can
   provide a function of type `Bool -> String -> String` that generates a custom GraphQL type name. The first argument is a `Bool` that is `True` if the type is an input, and `False` otherwise. The second
-  argument is a `String` representing the initial, auto-generated GraphQL type name. The function returns the desired type name.
+  argument is a `String` representing the initial, auto-generated GraphQL type name. The function returns the desired type name. thanks @nalchevanidze & @bradsherman
 
   e.g this schema will not fail. morpheus will generate types: `Deity` and `InputDeity`
 
@@ -18,8 +18,9 @@
   }
   deriving (Show, Generic)
 
-  deityTypeNameModifier True original = "Input" ++ original
-  deityTypeNameModifier False original = "Output" ++ original
+  deityTypeNameModifier isInput original =
+    | isInput = "Input" ++ original
+    | otherwise = original
 
   instance GQLType Deity where
     typeOptions _ opt = opt {typeNameModifier = deityTypeNameModifier}

--- a/src/Data/Morpheus/Server/Types/GQLType.hs
+++ b/src/Data/Morpheus/Server/Types/GQLType.hs
@@ -102,16 +102,13 @@ data GQLTypeOptions = GQLTypeOptions
     typeNameModifier :: Bool -> String -> String
   }
 
-defaultTypeNameModifier :: Bool -> String -> String
-defaultTypeNameModifier _ original = original
-
 defaultTypeOptions :: GQLTypeOptions
 defaultTypeOptions =
   GQLTypeOptions
     { fieldLabelModifier = id,
       constructorTagModifier = id,
       -- default is just a pass through for the original type name
-      typeNameModifier = defaultTypeNameModifier
+      typeNameModifier = const id
     }
 
 __typeData ::
@@ -133,13 +130,11 @@ getTypeConstructors = ignoreResolver . splitTyConApp . typeRep
 deriveTypeData :: Typeable a => f a -> (Bool -> String -> String) -> TypeCategory -> TypeData
 deriveTypeData proxy typeNameModifier cat =
   TypeData
-    { gqlTypeName = TypeName . pack $ typeNameModifier (isInput cat) originalTypeName,
+    { gqlTypeName = TypeName . pack $ typeNameModifier (cat == IN) originalTypeName,
       gqlWrappers = [],
       gqlFingerprint = getFingerprint cat proxy
     }
   where
-    isInput IN = True
-    isInput _ = False
     originalTypeName = unpack . readTypeName $ getTypename proxy
 
 getFingerprint :: Typeable a => TypeCategory -> f a -> TypeFingerprint

--- a/src/Data/Morpheus/Server/Types/GQLType.hs
+++ b/src/Data/Morpheus/Server/Types/GQLType.hs
@@ -130,7 +130,6 @@ getTypeConstructorNames = fmap (pack . tyConName . replacePairCon) . getTypeCons
 getTypeConstructors :: Typeable a => f a -> [TyCon]
 getTypeConstructors = ignoreResolver . splitTyConApp . typeRep
 
--- { gqlTypeName = (TypeName . pack . typeNameModifier) $ unpack . readTypeName $ prefix shouldPrefix cat <> getTypename proxy,
 deriveTypeData :: Typeable a => f a -> (Bool -> String -> String) -> TypeCategory -> TypeData
 deriveTypeData proxy typeNameModifier cat =
   TypeData

--- a/src/Data/Morpheus/Server/Types/SchemaT.hs
+++ b/src/Data/Morpheus/Server/Types/SchemaT.hs
@@ -28,7 +28,6 @@ import Data.Morpheus.Internal.Utils
 import Data.Morpheus.Types.Internal.AST
   ( ANY,
     CONST,
-    CONST,
     OBJECT,
     Schema (..),
     TypeCategory (..),
@@ -117,16 +116,16 @@ checkTypeColisions = fmap Map.elems . foldM collectTypes Map.empty
 
 failureRequirePrefix :: TypeName -> Eventless b
 failureRequirePrefix typename =
-  failure
-    $ globalErrorMessage
-    $ "It appears that the Haskell type "
-      <> msg typename
-      <> " was used as both input and output type, which is not allowed by GraphQL specifications."
-      <> "\n\n "
-      <> "If you enable \"{ prefixInputType = True }\" in \"GQLType.typeOptions\", "
-      <> "the compiler can generate a new input type "
-      <> msg ("Input" <> typename)
-      <> " to solve this problem."
+  failure $
+    globalErrorMessage $
+      "It appears that the Haskell type "
+        <> msg typename
+        <> " was used as both input and output type, which is not allowed by GraphQL specifications."
+        <> "\n\n "
+        <> "If you supply \"typeNameModifier\" in \"GQLType.typeOptions\", "
+        <> "you can override the default type names for "
+        <> msg typename
+        <> " to solve this problem."
 
 withSameCategory :: TypeFingerprint -> TypeFingerprint
 withSameCategory (TypeableFingerprint _ xs) = TypeableFingerprint OUT xs

--- a/test/Feature/TypeCategoryCollision/Fail/failOnColision/response.json
+++ b/test/Feature/TypeCategoryCollision/Fail/failOnColision/response.json
@@ -1,7 +1,7 @@
 {
   "errors": [
     {
-      "message": "It appears that the Haskell type \"Deity\" was used as both input and output type, which is not allowed by GraphQL specifications.\n\n If you enable \"{ prefixInputType = True }\" in \"GQLType.typeOptions\", the compiler can generate a new input type \"InputDeity\" to solve this problem.",
+      "message": "It appears that the Haskell type \"Deity\" was used as both input and output type, which is not allowed by GraphQL specifications.\n\n If you supply \"typeNameModifier\" in \"GQLType.typeOptions\", you can override the default type names for \"Deity\" to solve this problem.",
       "locations": []
     }
   ]

--- a/test/Feature/TypeCategoryCollision/Success/API.hs
+++ b/test/Feature/TypeCategoryCollision/Success/API.hs
@@ -29,8 +29,12 @@ data Deity = Deity
   }
   deriving (Show, Generic)
 
+nonClashingTypeNameModifier :: Bool -> String -> String
+nonClashingTypeNameModifier True original = "Input" <> original
+nonClashingTypeNameModifier False original = original
+
 instance GQLType Deity where
-  typeOptions _ opt = opt {prefixInputType = True}
+  typeOptions _ opt = opt {typeNameModifier = nonClashingTypeNameModifier}
 
 newtype DeityArgs = DeityArgs
   { input :: Deity

--- a/test/Feature/TypeCategoryCollision/Success/API.hs
+++ b/test/Feature/TypeCategoryCollision/Success/API.hs
@@ -30,7 +30,7 @@ data Deity = Deity
   deriving (Show, Generic)
 
 nonClashingTypeNameModifier :: Bool -> String -> String
-nonClashingTypeNameModifier True original = "Input" <> original
+nonClashingTypeNameModifier True original = "Input" ++ original
 nonClashingTypeNameModifier False original = original
 
 instance GQLType Deity where


### PR DESCRIPTION
fixes #558

This is a first draft. I don't have much experience on large Haskell projects, so I just wanted to get this up and get a conversation going. 

It seems inefficient to `upack` and apply the modifier then `pack` again, but I'm not exactly sure what the implications are of `typeNameModifier :: TypeName -> TypeName`.

I do not understand what `proxy` is doing in the code, so could I please have a bit of an explanation about that?

Also, I think I'll need more direction on writing tests for this change.

Thanks in advance for the feedback!