### PR TITLE
Add defineBy*File' variant to client that takes a Q FilePath

### DIFF
--- a/morpheus-graphql-client/changelog.md
+++ b/morpheus-graphql-client/changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Minor Changes
+
+- Add defineBy*File' variants that take a `Q FilePath` [#584](https://github.com/morpheusgraphql/morpheus-graphql/pull/584)
+
 ## 0.17.0 - 25.02.2021
 
 ### Breaking changes

--- a/morpheus-graphql-client/src/Data/Morpheus/Client.hs
+++ b/morpheus-graphql-client/src/Data/Morpheus/Client.hs
@@ -7,8 +7,10 @@ module Data.Morpheus.Client
     defineQuery,
     defineByDocument,
     defineByDocumentFile,
+    defineByDocumentFile',
     defineByIntrospection,
     defineByIntrospectionFile,
+    defineByIntrospectionFile',
     ScalarValue (..),
     DecodeScalar (..),
     EncodeScalar (..),
@@ -58,10 +60,18 @@ defineByDocumentFile filePath args = do
   qAddDependentFile filePath
   defineByDocument (L.readFile filePath) args
 
+-- | This variant exposes 'Q FilePath' enabling the use of TH to generate the 'FilePath'. For example, https://hackage.haskell.org/package/file-embed-0.0.13.0/docs/Data-FileEmbed.html#v:makeRelativeToProject can be used to handle multi package projects more reliably.
+defineByDocumentFile' :: Q FilePath -> (ExecutableDocument, String) -> Q [Dec]
+defineByDocumentFile' qFilePath args = qFilePath >>= flip defineByDocumentFile args
+
 defineByIntrospectionFile :: FilePath -> (ExecutableDocument, String) -> Q [Dec]
 defineByIntrospectionFile filePath args = do
   qAddDependentFile filePath
   defineByIntrospection (L.readFile filePath) args
+
+-- | This variant exposes 'Q FilePath' enabling the use of TH to generate the 'FilePath'. For example, https://hackage.haskell.org/package/file-embed-0.0.13.0/docs/Data-FileEmbed.html#v:makeRelativeToProject can be used to handle multi package projects more reliably.
+defineByIntrospectionFile' :: Q FilePath -> (ExecutableDocument, String) -> Q [Dec]
+defineByIntrospectionFile' qFilePath args = qFilePath >>= flip defineByIntrospectionFile args
 
 defineByDocument :: IO ByteString -> (ExecutableDocument, String) -> Q [Dec]
 defineByDocument doc = defineQuery (schemaByDocument doc)


### PR DESCRIPTION
This enables using utilities such as https://hackage.haskell.org/package/file-embed-0.0.13.0/docs/Data-FileEmbed.html#v:makeRelativeToProject
which can be used to work around file path issues when using multi package projects.

Specifically, if I run `stack repl subproject` which uses `defineByDocumentFile` it fails as the path is calculated differently via `stack repl` as compared to when you run the code or run it with tests. This issue also breaks haskell language server, as it relies on `stack repl` as well.

This changes enables using `makeRelativeToProject` which will hopefully make everything work. ~~Currently I am just putting this up to test that it does fix it.~~ Indeed this does fix the issue.

This is ready for review.