### PR TITLE
Update Readme to add extra-deps for app and core

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ resolver: lts-16.2
 
 extra-deps:
   - morpheus-graphql-0.17.0
+  - morpheus-graphql-app-0.17.0
+  - morpheus-graphql-core-0.17.0
 ```
 
 As Morpheus is quite new, make sure stack can find morpheus-graphql by running `stack upgrade` and `stack update`


### PR DESCRIPTION
I was trying to setup Morpheus and followed the readme. I ended up getting the following error on `stack build`

```
Error: While constructing the build plan, the following exceptions were encountered:

In the dependencies for morpheus-graphql-0.17.0:
    morpheus-graphql-app must match >=0.17.0 && <0.18.0, but the stack configuration has no specified version  (latest matching
                         version is 0.17.0)
    morpheus-graphql-core-0.12.0 from stack configuration does not match >=0.17.0 && <0.18.0  (latest matching version
                                 is 0.17.0)
needed due to insurance-0.1.0.0 -> morpheus-graphql-0.17.0

Some different approaches to resolving this:

  * Recommended action: try adding the following to your extra-deps in /Users/psilospore/develop/someproject/stack.yaml:

- morpheus-graphql-app-0.17.0@sha256:7561a7b371673417c8d7e4200ce2e79f01b5a8557547efdf341136459132d9cc,5425
- morpheus-graphql-core-0.17.0@sha256:4192366e2c23594a435364cc42832f2949620b8b116a69b57e59fde7111b1a0d,12939
```

Adding the following worked:
```
  - morpheus-graphql-app-0.17.0
  - morpheus-graphql-core-0.17.0
```

I also noticed another project added those dependencies in: https://github.com/nalchevanidze/morpheus-haxl-example/blob/main/stack.yaml