### PR TITLE
Get things working with GHC 9

### DIFF
--- a/morpheus-graphql-code-gen/morpheus-graphql-code-gen.cabal
+++ b/morpheus-graphql-code-gen/morpheus-graphql-code-gen.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: d945b3f1dd7bd5e281110793806a6ad49da4c76def1ab6e498828d3a2d307743
+-- hash: 32983807cf2e7ed977d5c8fe4f5fa9dc9d1f9c4620fcaa6f6f52a85e72048036
 
 name:           morpheus-graphql-code-gen
 version:        0.17.0
@@ -50,7 +50,7 @@ library
     , morpheus-graphql-core >=0.17.0 && <0.18.0
     , optparse-applicative >=0.12 && <0.17
     , prettyprinter >=1.2 && <2.0
-    , relude >=0.3.0 && <1.0
+    , relude >=0.3.0 && <1.1
     , template-haskell >=2.0 && <3.0
     , text >=1.2.3.0 && <1.3
     , unordered-containers >=0.2.8.0 && <0.3
@@ -72,7 +72,7 @@ executable morpheus
     , morpheus-graphql-core >=0.17.0 && <0.18.0
     , optparse-applicative >=0.12 && <0.17
     , prettyprinter >=1.2 && <2.0
-    , relude >=0.3.0 && <1.0
+    , relude >=0.3.0 && <1.1
     , template-haskell >=2.0 && <3.0
     , text >=1.2.3.0 && <1.3
     , unordered-containers >=0.2.8.0 && <0.3

--- a/morpheus-graphql-code-gen/package.yaml
+++ b/morpheus-graphql-code-gen/package.yaml
@@ -25,7 +25,7 @@ dependencies:
   - prettyprinter         >= 1.2       && <  2.0
   - unordered-containers  >= 0.2.8.0   && <  0.3
   - containers            >=0.4.2.1    && <  0.7
-  - relude                >= 0.3.0     && <  1.0
+  - relude                >= 0.3.0     && <  1.1
   - template-haskell      >= 2.0       && <  3.0
 
 library:

--- a/morpheus-graphql-code-gen/src/Data/Morpheus/CodeGen/Interpreting/Transform.hs
+++ b/morpheus-graphql-code-gen/src/Data/Morpheus/CodeGen/Interpreting/Transform.hs
@@ -9,6 +9,7 @@
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE CPP #-}
 
 module Data.Morpheus.CodeGen.Interpreting.Transform
   ( parseServerTypeDefinitions,
@@ -85,7 +86,11 @@ isParametrizedHaskellType :: Info -> Bool
 isParametrizedHaskellType (TyConI x) = not $ null $ getTypeVariables x
 isParametrizedHaskellType _ = False
 
+#if MIN_VERSION_template_haskell(2,17,0)
+getTypeVariables :: Dec -> [TyVarBndr ()]
+#else
 getTypeVariables :: Dec -> [TyVarBndr]
+#endif
 getTypeVariables (DataD _ _ args _ _ _) = args
 getTypeVariables (NewtypeD _ _ args _ _ _) = args
 getTypeVariables (TySynD _ args _) = args

--- a/morpheus-graphql-core/src/Data/Morpheus/Types/Internal/AST/Name.hs
+++ b/morpheus-graphql-core/src/Data/Morpheus/Types/Internal/AST/Name.hs
@@ -50,6 +50,13 @@ import qualified Data.Text as T
 import Language.Haskell.TH
   ( stringE,
   )
+#if MIN_VERSION_template_haskell(2,17,0)
+import Language.Haskell.TH
+  ( Quote,
+    Code,
+    unsafeCodeCoerce
+  )
+#endif
 import Language.Haskell.TH.Syntax
   ( Lift (..),
     Q,
@@ -91,7 +98,14 @@ packName = Name
 instance Lift (Name t) where
   lift = stringE . T.unpack . unpackName
 
-#if MIN_VERSION_template_haskell(2,16,0)
+#if MIN_VERSION_template_haskell(2,17,0)
+  -- liftTyped :: Quote m => Name t -> Code m (Name t)
+  liftTyped = liftTypedString . unpackName
+    where
+      liftTypedString :: (Quote m) => Text -> Code m (Name t)
+      liftTypedString = unsafeCodeCoerce . stringE . T.unpack
+      {-# INLINE liftTypedString #-}
+#elif MIN_VERSION_template_haskell(2,16,0)
   liftTyped = liftTypedString . unpackName
     where
       liftTypedString :: IsString a => Text -> Q (TExp a)

--- a/src/Data/Morpheus/Server/Deriving/Channels.hs
+++ b/src/Data/Morpheus/Server/Deriving/Channels.hs
@@ -102,7 +102,7 @@ class GetChannel e a | a -> e where
   getChannel :: a -> ChannelRes e
 
 instance GetChannel e (SubscriptionField (Resolver SUBSCRIPTION e m a)) where
-  getChannel = const . pure . DerivedChannel . channel
+  getChannel x = const $ pure $ DerivedChannel $ channel x
 
 instance
   DecodeConstraint arg =>

--- a/stack-ghc9.yaml
+++ b/stack-ghc9.yaml
@@ -2,23 +2,15 @@
 resolver: nightly-2021-09-12
 save-hackage-creds: false
 packages:
-  # - morpheus-graphql-benchmarks
+  - morpheus-graphql-benchmarks
   # - morpheus-graphql-examples-scotty
-  # - morpheus-graphql-examples-servant
-  # - morpheus-graphql-examples-client
-  # - morpheus-graphql-examples-code-gen
+  - morpheus-graphql-examples-servant
+  - morpheus-graphql-examples-client
+  - morpheus-graphql-examples-code-gen
   - morpheus-graphql-subscriptions
   - morpheus-graphql-client
   - morpheus-graphql-core
   - morpheus-graphql-app
   - morpheus-graphql-tests
   - morpheus-graphql-code-gen
-  # - .
-
-# extra-deps:
-# - git: https://github.com/codedownio/dependent-sum.git
-#   commit: 836a72104e25c94fc85d389b90edb76d4109a59b
-#   subdirs:
-#   - dependent-sum
-#   - dependent-sum-template
-# - dependent-map-0.4.0.0@sha256:ca2b131046f4340a1c35d138c5a003fe4a5be96b14efc26291ed35fd08c62221,1657
+  - .

--- a/stack-ghc9.yaml
+++ b/stack-ghc9.yaml
@@ -1,0 +1,24 @@
+# 9.0.1
+resolver: nightly-2021-09-12
+save-hackage-creds: false
+packages:
+  # - morpheus-graphql-benchmarks
+  # - morpheus-graphql-examples-scotty
+  # - morpheus-graphql-examples-servant
+  # - morpheus-graphql-examples-client
+  - morpheus-graphql-examples-code-gen
+  - morpheus-graphql-subscriptions
+  - morpheus-graphql-client
+  - morpheus-graphql-core
+  - morpheus-graphql-app
+  - morpheus-graphql-tests
+  - morpheus-graphql-code-gen
+  # - .
+
+# extra-deps:
+# - git: https://github.com/codedownio/dependent-sum.git
+#   commit: 836a72104e25c94fc85d389b90edb76d4109a59b
+#   subdirs:
+#   - dependent-sum
+#   - dependent-sum-template
+# - dependent-map-0.4.0.0@sha256:ca2b131046f4340a1c35d138c5a003fe4a5be96b14efc26291ed35fd08c62221,1657

--- a/stack-ghc9.yaml
+++ b/stack-ghc9.yaml
@@ -6,7 +6,7 @@ packages:
   # - morpheus-graphql-examples-scotty
   # - morpheus-graphql-examples-servant
   # - morpheus-graphql-examples-client
-  - morpheus-graphql-examples-code-gen
+  # - morpheus-graphql-examples-code-gen
   - morpheus-graphql-subscriptions
   - morpheus-graphql-client
   - morpheus-graphql-core


### PR DESCRIPTION
This PR gets every package except `morpheus-graphql-examples-scotty` building with GHC 9. The test suites run also. The Scotty package has a few problematic dependencies still. Resolves #632 