### PR TITLE
Update CI matrix and default resolver

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -12,6 +12,7 @@ jobs:
           - { lts: "-14.14" } # ghc-8.6.5
           - { lts: "-15.3" } # ghc-8.8.2
           - { lts: "-16.2" } # ghc-8.8.3
+          - { lts: "-ghc9" } # ghc-9.0.1
           - { lts: "" } # nightly 8.10.1
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -13,7 +13,7 @@ jobs:
           - { lts: "-15.3" } # ghc-8.8.2
           - { lts: "-16.2" } # ghc-8.8.3
           - { lts: "-ghc9" } # ghc-9.0.1
-          - { lts: "" } # nightly 8.10.1
+          - { lts: "" } # nightly 8.10.7
     runs-on: ubuntu-latest
     steps:
       - name: Prepare OS

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,5 @@
-# 8.10.1
-resolver: nightly-2021-03-29
+# 8.10.7
+resolver: lts-18.10
 save-hackage-creds: false
 packages:
   - morpheus-graphql-benchmarks


### PR DESCRIPTION
Should have included these in my previous PR:

* Add GHC 9 to the CI matrix
* Update the default resolver to the latest in the 8.10 series, 8.10.7