### PR TITLE
Fix export of GQLTypeOptions and document it a bit.

### DIFF
--- a/src/Data/Morpheus/Server/Types/GQLType.hs
+++ b/src/Data/Morpheus/Server/Types/GQLType.hs
@@ -21,11 +21,7 @@ module Data.Morpheus.Server.Types.GQLType
         defaultValues,
         __type
       ),
-    GQLTypeOptions
-      ( fieldLabelModifier,
-        constructorTagModifier,
-        typeNameModifier
-      ),
+    GQLTypeOptions (..),
     defaultTypeOptions,
     TypeData (..),
     __isObjectKind,
@@ -98,14 +94,31 @@ data TypeData = TypeData
   }
   deriving (Show)
 
+-- | Options that specify how to map GraphQL field, type, and constructor names
+-- to and from their Haskell equivalent.
+--
+-- Options can be set using record syntax on 'defaultOptions' with the fields
+-- below.
 data GQLTypeOptions = GQLTypeOptions
-  { fieldLabelModifier :: String -> String,
+  { -- | Function applied to field labels.
+    -- Handy for removing common record prefixes for example.
+    fieldLabelModifier :: String -> String,
+    -- | Function applied to constructor tags.
     constructorTagModifier :: String -> String,
-    -- Construct a new type name depending on whether it is an input,
-    -- and being given the original type name
+    -- | Construct a new type name depending on whether it is an input,
+    -- and being given the original type name.
     typeNameModifier :: Bool -> String -> String
   }
 
+-- | Default encoding 'GQLTypeOptions':
+--
+-- @
+-- 'GQLTypeOptions'
+--   { 'fieldLabelModifier'      = id
+--   , 'constructorTagModifier'  = id
+--   , 'typeNameModifier'        = const id
+--   }
+-- @
 defaultTypeOptions :: GQLTypeOptions
 defaultTypeOptions =
   GQLTypeOptions
@@ -194,9 +207,15 @@ class ToValue (KIND a) => GQLType a where
   type KIND a :: DerivingKind
   type KIND a = TYPE
 
+  -- | A description of the type.
+  --
+  -- Used for documentation in the GraphQL schema.
   description :: f a -> Maybe Text
   description _ = Nothing
 
+  -- | A dictionary of descriptions for fields, keyed on field name.
+  --
+  -- Used for documentation in the GraphQL schema.
   getDescriptions :: f a -> Map Text Description
   getDescriptions _ = mempty
 

--- a/src/Data/Morpheus/Types.hs
+++ b/src/Data/Morpheus/Types.hs
@@ -54,10 +54,16 @@ module Data.Morpheus.Types
     App,
     RenderGQL,
     render,
-    GQLTypeOptions (..),
     TypeGuard (..),
     Arg (..),
     NamedResolvers (..),
+
+    -- * GQLType naming configuration
+    GQLTypeOptions,
+    defaultTypeOptions,
+    fieldLabelModifier,
+    constructorTagModifier,
+    typeNameModifier,
   )
 where
 
@@ -86,6 +92,7 @@ import Data.Morpheus.NamedResolvers
 import Data.Morpheus.Server.Types.GQLType
   ( GQLType (..),
     GQLTypeOptions (..),
+    defaultTypeOptions,
   )
 import Data.Morpheus.Server.Types.Types
   ( Arg (..),


### PR DESCRIPTION
The currently published version of `morpheus-graphql` doesn't export any way to actually use `GQLTypeOptions`. This PR fixes that, and adds a little additional documentation:

## Before

![image](https://user-images.githubusercontent.com/69209/134646686-9a69fdd8-9048-40be-92cc-2d24ab8fa5a7.png)

## After

![image](https://user-images.githubusercontent.com/69209/134646737-9c67594f-08dd-4109-b8e7-ba79572155e7.png)
