### PR TITLE
Allow Nothing values for locations in GraphQL errors

### DIFF
--- a/morpheus-graphql-core/src/Data/Morpheus/Types/Internal/AST/Error.hs
+++ b/morpheus-graphql-core/src/Data/Morpheus/Types/Internal/AST/Error.hs
@@ -56,7 +56,9 @@ at err pos = atPositions err [pos]
 {-# INLINE at #-}
 
 atPositions :: Foldable t => GQLError -> t Position -> GQLError
-atPositions GQLError {..} pos = GQLError {locations = locations <> toList pos, ..}
+atPositions GQLError {..} pos = case toList pos of
+  [] -> GQLError {..}
+  posList -> GQLError {locations = locations <> Just posList, ..}
 {-# INLINE atPositions #-}
 
 manyMsg :: (Foldable t, Msg a) => t a -> GQLError
@@ -79,7 +81,7 @@ instance Semigroup ErrorType where
 
 data GQLError = GQLError
   { message :: Message,
-    locations :: [Position],
+    locations :: Maybe [Position],
     errorType :: Maybe ErrorType,
     extensions :: Maybe (Map Text Value)
   }
@@ -114,7 +116,7 @@ instance Msg Text where
   msg message =
     GQLError
       { message,
-        locations = [],
+        locations = Nothing,
         errorType = Nothing,
         extensions = Nothing
       }

--- a/morpheus-graphql-core/test/query/parsing/selection-set/empty-selection/response.json
+++ b/morpheus-graphql-core/test/query/parsing/selection-set/empty-selection/response.json
@@ -1,6 +1,5 @@
 [
   {
-    "message": "empty selection sets are not supported.",
-    "locations": []
+    "message": "empty selection sets are not supported."
   }
 ]

--- a/morpheus-graphql-core/test/schema/parsing/schema-definition/fail/dupplicate-field/query-mutation-subscription/response.json
+++ b/morpheus-graphql-core/test/schema/parsing/schema-definition/fail/dupplicate-field/query-mutation-subscription/response.json
@@ -1,30 +1,23 @@
 [
   {
-    "message": "There can Be only One TypeDefinition for schema.\"query\"",
-    "locations": []
+    "message": "There can Be only One TypeDefinition for schema.\"query\""
   },
   {
-    "message": "There can Be only One TypeDefinition for schema.\"query\"",
-    "locations": []
+    "message": "There can Be only One TypeDefinition for schema.\"query\""
   },
   {
-    "message": "There can Be only One TypeDefinition for schema.\"mutation\"",
-    "locations": []
+    "message": "There can Be only One TypeDefinition for schema.\"mutation\""
   },
   {
-    "message": "There can Be only One TypeDefinition for schema.\"mutation\"",
-    "locations": []
+    "message": "There can Be only One TypeDefinition for schema.\"mutation\""
   },
   {
-    "message": "There can Be only One TypeDefinition for schema.\"subscription\"",
-    "locations": []
+    "message": "There can Be only One TypeDefinition for schema.\"subscription\""
   },
   {
-    "message": "There can Be only One TypeDefinition for schema.\"subscription\"",
-    "locations": []
+    "message": "There can Be only One TypeDefinition for schema.\"subscription\""
   },
   {
-    "message": "There can Be only One TypeDefinition for schema.\"subscription\"",
-    "locations": []
+    "message": "There can Be only One TypeDefinition for schema.\"subscription\""
   }
 ]

--- a/morpheus-graphql-core/test/schema/parsing/schema-definition/fail/dupplicate-field/query/response.json
+++ b/morpheus-graphql-core/test/schema/parsing/schema-definition/fail/dupplicate-field/query/response.json
@@ -1,14 +1,11 @@
 [
   {
-    "message": "There can Be only One TypeDefinition for schema.\"query\"",
-    "locations": []
+    "message": "There can Be only One TypeDefinition for schema.\"query\""
   },
   {
-    "message": "There can Be only One TypeDefinition for schema.\"query\"",
-    "locations": []
+    "message": "There can Be only One TypeDefinition for schema.\"query\""
   },
   {
-    "message": "There can Be only One TypeDefinition for schema.\"query\"",
-    "locations": []
+    "message": "There can Be only One TypeDefinition for schema.\"query\""
   }
 ]

--- a/morpheus-graphql-core/test/schema/parsing/schema-definition/fail/dupplicate-schema-definition/response.json
+++ b/morpheus-graphql-core/test/schema/parsing/schema-definition/fail/dupplicate-schema-definition/response.json
@@ -1,5 +1,5 @@
 [
-  { "message": "There can Be only One SchemaDefinition.", "locations": [] },
-  { "message": "There can Be only One SchemaDefinition.", "locations": [] },
-  { "message": "There can Be only One SchemaDefinition.", "locations": [] }
+  { "message": "There can Be only One SchemaDefinition." },
+  { "message": "There can Be only One SchemaDefinition." },
+  { "message": "There can Be only One SchemaDefinition." }
 ]

--- a/morpheus-graphql-core/test/schema/validation/default-value/argument/missing-field/response.json
+++ b/morpheus-graphql-core/test/schema/validation/default-value/argument/missing-field/response.json
@@ -1,22 +1,17 @@
 [
   {
-    "message": "Field Query.field(i1:) got invalid default value. in field \"field\": Undefined Field \"field\".",
-    "locations": []
+    "message": "Field Query.field(i1:) got invalid default value. in field \"field\": Undefined Field \"field\"."
   },
   {
-    "message": "Field Query.field(i1:) got invalid default value. in field \"field\": Undefined Field \"field2\".",
-    "locations": []
+    "message": "Field Query.field(i1:) got invalid default value. in field \"field\": Undefined Field \"field2\"."
   },
   {
-    "message": "Field Query.field(i3:) got invalid default value. in field \"field.field\": Undefined Field \"field\".",
-    "locations": []
+    "message": "Field Query.field(i3:) got invalid default value. in field \"field.field\": Undefined Field \"field\"."
   },
   {
-    "message": "Field Query.field(i3:) got invalid default value. in field \"field\": Undefined Field \"field2\".",
-    "locations": []
+    "message": "Field Query.field(i3:) got invalid default value. in field \"field\": Undefined Field \"field2\"."
   },
   {
-    "message": "Field Query.field(i2:) got invalid default value. Undefined Field \"field\".",
-    "locations": []
+    "message": "Field Query.field(i2:) got invalid default value. Undefined Field \"field\"."
   }
 ]

--- a/morpheus-graphql-core/test/schema/validation/default-value/argument/unexpected-value/response.json
+++ b/morpheus-graphql-core/test/schema/validation/default-value/argument/unexpected-value/response.json
@@ -1,30 +1,23 @@
 [
   {
-    "message": "Field Query.field(i1:) got invalid default value. in field \"field1.field2\": Expected type \"String\" found 1.",
-    "locations": []
+    "message": "Field Query.field(i1:) got invalid default value. in field \"field1.field2\": Expected type \"String\" found 1."
   },
   {
-    "message": "Field Query.field(i1:) got invalid default value. in field \"field2\": Expected type \"String\" found true.",
-    "locations": []
+    "message": "Field Query.field(i1:) got invalid default value. in field \"field2\": Expected type \"String\" found true."
   },
   {
-    "message": "Field Query.field(i5:) got invalid default value. Expected type \"Int\" found \"some text\".",
-    "locations": []
+    "message": "Field Query.field(i5:) got invalid default value. Expected type \"Int\" found \"some text\"."
   },
   {
-    "message": "Field Query.field(i3:) got invalid default value. Expected type \"TestEnum\" found EnumBB.",
-    "locations": []
+    "message": "Field Query.field(i3:) got invalid default value. Expected type \"TestEnum\" found EnumBB."
   },
   {
-    "message": "Field Query.field(i4:) got invalid default value. Expected type \"ID\" found true.",
-    "locations": []
+    "message": "Field Query.field(i4:) got invalid default value. Expected type \"ID\" found true."
   },
   {
-    "message": "Field Query.field(i2:) got invalid default value. in field \"field1\": Expected type \"ID\" found { field3: 2344 }.",
-    "locations": []
+    "message": "Field Query.field(i2:) got invalid default value. in field \"field1\": Expected type \"ID\" found { field3: 2344 }."
   },
   {
-    "message": "Field Query.field(i2:) got invalid default value. in field \"field2\": Expected type \"String\" found 123.",
-    "locations": []
+    "message": "Field Query.field(i2:) got invalid default value. in field \"field2\": Expected type \"String\" found 123."
   }
 ]

--- a/morpheus-graphql-core/test/schema/validation/default-value/argument/unknown-field/response.json
+++ b/morpheus-graphql-core/test/schema/validation/default-value/argument/unknown-field/response.json
@@ -1,14 +1,11 @@
 [
   {
-    "message": "Field Query.field(i1:) got invalid default value. Unknown Field \"field2\".",
-    "locations": []
+    "message": "Field Query.field(i1:) got invalid default value. Unknown Field \"field2\"."
   },
   {
-    "message": "Field Query.field(i1:) got invalid default value. in field \"field\": Unknown Field \"field2\".",
-    "locations": []
+    "message": "Field Query.field(i1:) got invalid default value. in field \"field\": Unknown Field \"field2\"."
   },
   {
-    "message": "Field Query.field(i1:) got invalid default value. in field \"field.field\": Unknown Field \"field3\".",
-    "locations": []
+    "message": "Field Query.field(i1:) got invalid default value. in field \"field.field\": Unknown Field \"field3\"."
   }
 ]

--- a/morpheus-graphql-core/test/schema/validation/default-value/field/missing-field/response.json
+++ b/morpheus-graphql-core/test/schema/validation/default-value/field/missing-field/response.json
@@ -1,10 +1,8 @@
 [
   {
-    "message": "Field Input3.field1 got invalid default value. in field \"field\": Undefined Field \"field\".",
-    "locations": []
+    "message": "Field Input3.field1 got invalid default value. in field \"field\": Undefined Field \"field\"."
   },
   {
-    "message": "Field Input3.field1 got invalid default value. Undefined Field \"field2\".",
-    "locations": []
+    "message": "Field Input3.field1 got invalid default value. Undefined Field \"field2\"."
   }
 ]

--- a/morpheus-graphql-core/test/schema/validation/default-value/field/unexpected-value/response.json
+++ b/morpheus-graphql-core/test/schema/validation/default-value/field/unexpected-value/response.json
@@ -1,42 +1,32 @@
 [
   {
-    "message": "Field Input2.objectField got invalid default value. in field \"field1\": Expected type \"ID!\" found true.",
-    "locations": []
+    "message": "Field Input2.objectField got invalid default value. in field \"field1\": Expected type \"ID!\" found true."
   },
   {
-    "message": "Field Input2.objectField got invalid default value. in field \"field4\": Expected type \"TestEnum!\" found 1.",
-    "locations": []
+    "message": "Field Input2.objectField got invalid default value. in field \"field4\": Expected type \"TestEnum!\" found 1."
   },
   {
-    "message": "Field Input2.objectField got invalid default value. in field \"field5\": Expected type \"TestEnum\" found \"some text\".",
-    "locations": []
+    "message": "Field Input2.objectField got invalid default value. in field \"field5\": Expected type \"TestEnum\" found \"some text\"."
   },
   {
-    "message": "Field Input2.objectField got invalid default value. in field \"field2\": Expected type \"String!\" found true.",
-    "locations": []
+    "message": "Field Input2.objectField got invalid default value. in field \"field2\": Expected type \"String!\" found true."
   },
   {
-    "message": "Field Input2.objectField got invalid default value. in field \"field3\": Expected type \"TestEnum\" found true.",
-    "locations": []
+    "message": "Field Input2.objectField got invalid default value. in field \"field3\": Expected type \"TestEnum\" found true."
   },
   {
-    "message": "Field Input1.field1 got invalid default value. Expected type \"ID!\" found EnumA.",
-    "locations": []
+    "message": "Field Input1.field1 got invalid default value. Expected type \"ID!\" found EnumA."
   },
   {
-    "message": "Field Input1.field4 got invalid default value. Expected type \"TestEnum!\" found 1.",
-    "locations": []
+    "message": "Field Input1.field4 got invalid default value. Expected type \"TestEnum!\" found 1."
   },
   {
-    "message": "Field Input1.field5 got invalid default value. Expected type \"TestEnum\" found \"some text\".",
-    "locations": []
+    "message": "Field Input1.field5 got invalid default value. Expected type \"TestEnum\" found \"some text\"."
   },
   {
-    "message": "Field Input1.field2 got invalid default value. Expected type \"String!\" found EnumA.",
-    "locations": []
+    "message": "Field Input1.field2 got invalid default value. Expected type \"String!\" found EnumA."
   },
   {
-    "message": "Field Input1.field3 got invalid default value. Expected type \"TestEnum\" found UnknownEnum.",
-    "locations": []
+    "message": "Field Input1.field3 got invalid default value. Expected type \"TestEnum\" found UnknownEnum."
   }
 ]

--- a/morpheus-graphql-core/test/schema/validation/default-value/field/unknown-field/response.json
+++ b/morpheus-graphql-core/test/schema/validation/default-value/field/unknown-field/response.json
@@ -1,14 +1,11 @@
 [
   {
-    "message": "Field Input3.field got invalid default value. Unknown Field \"field2\".",
-    "locations": []
+    "message": "Field Input3.field got invalid default value. Unknown Field \"field2\"."
   },
   {
-    "message": "Field Input3.field got invalid default value. in field \"field\": Unknown Field \"field2\".",
-    "locations": []
+    "message": "Field Input3.field got invalid default value. in field \"field\": Unknown Field \"field2\"."
   },
   {
-    "message": "Field Input3.field got invalid default value. in field \"field\": Unknown Field \"field3\".",
-    "locations": []
+    "message": "Field Input3.field got invalid default value. in field \"field\": Unknown Field \"field3\"."
   }
 ]

--- a/morpheus-graphql-core/test/schema/validation/interface/field-args/fail/response.json
+++ b/morpheus-graphql-core/test/schema/validation/interface/field-args/fail/response.json
@@ -1,18 +1,14 @@
 [
   {
-    "message": "Interface field argument Character.name(id:) expected but Deity.name does not provide it.",
-    "locations": []
+    "message": "Interface field argument Character.name(id:) expected but Deity.name does not provide it."
   },
   {
-    "message": "Interface field argument Supernatural.power(id:) expects type \"ID!\" but Deity.power(id:) is type \"String!\".",
-    "locations": []
+    "message": "Interface field argument Supernatural.power(id:) expects type \"ID!\" but Deity.power(id:) is type \"String!\"."
   },
   {
-    "message": "Interface field Supernatural.power expects type \"[String!]!\" but Hero.power is type \"String!\".",
-    "locations": []
+    "message": "Interface field Supernatural.power expects type \"[String!]!\" but Hero.power is type \"String!\"."
   },
   {
-    "message": "Interface field argument Supernatural.power(id:) expects type \"ID!\" but Hero.power(id:) is type \"ID\".",
-    "locations": []
+    "message": "Interface field argument Supernatural.power(id:) expects type \"ID!\" but Hero.power(id:) is type \"ID\"."
   }
 ]

--- a/morpheus-graphql-core/test/schema/validation/interface/field-type/fail/response.json
+++ b/morpheus-graphql-core/test/schema/validation/interface/field-type/fail/response.json
@@ -1,14 +1,11 @@
 [
   {
-    "message": "Interface field Character.name expects type \"String\" but Deity.name is type \"Int\".",
-    "locations": []
+    "message": "Interface field Character.name expects type \"String\" but Deity.name is type \"Int\"."
   },
   {
-    "message": "Interface field Supernatural.power expects type \"[String!]!\" but Deity.power is type \"[String!]\".",
-    "locations": []
+    "message": "Interface field Supernatural.power expects type \"[String!]!\" but Deity.power is type \"[String!]\"."
   },
   {
-    "message": "Interface field Character.name expected but \"Hero\" does not provide it.",
-    "locations": []
+    "message": "Interface field Character.name expected but \"Hero\" does not provide it."
   }
 ]

--- a/morpheus-graphql-core/test/schema/validation/schema-definition/fail/non-object-kind/from-schema/response.json
+++ b/morpheus-graphql-core/test/schema/validation/schema-definition/fail/non-object-kind/from-schema/response.json
@@ -1,14 +1,11 @@
 [
   {
-    "message": "Query root type must be Object type if provided, it cannot be \"MyType\"",
-    "locations": []
+    "message": "Query root type must be Object type if provided, it cannot be \"MyType\""
   },
   {
-    "message": "Mutation root type must be Object type if provided, it cannot be \"MyUnion\"",
-    "locations": []
+    "message": "Mutation root type must be Object type if provided, it cannot be \"MyUnion\""
   },
   {
-    "message": "Subscription root type must be Object type if provided, it cannot be \"MyEnum\"",
-    "locations": []
+    "message": "Subscription root type must be Object type if provided, it cannot be \"MyEnum\""
   }
 ]

--- a/morpheus-graphql-core/test/schema/validation/schema-definition/fail/non-object-kind/without-schema/response.json
+++ b/morpheus-graphql-core/test/schema/validation/schema-definition/fail/non-object-kind/without-schema/response.json
@@ -1,14 +1,11 @@
 [
   {
-    "message": "Query root type must be Object type if provided, it cannot be \"Query\"",
-    "locations": []
+    "message": "Query root type must be Object type if provided, it cannot be \"Query\""
   },
   {
-    "message": "Mutation root type must be Object type if provided, it cannot be \"Mutation\"",
-    "locations": []
+    "message": "Mutation root type must be Object type if provided, it cannot be \"Mutation\""
   },
   {
-    "message": "Subscription root type must be Object type if provided, it cannot be \"Subscription\"",
-    "locations": []
+    "message": "Subscription root type must be Object type if provided, it cannot be \"Subscription\""
   }
 ]

--- a/morpheus-graphql-core/test/schema/validation/schema-definition/fail/required query/empty/response.json
+++ b/morpheus-graphql-core/test/schema/validation/schema-definition/fail/required query/empty/response.json
@@ -1,6 +1,5 @@
 [
   {
-    "message": "Query root type must be provided.",
-    "locations": []
+    "message": "Query root type must be provided."
   }
 ]

--- a/morpheus-graphql-core/test/schema/validation/schema-definition/fail/required query/no-query/response.json
+++ b/morpheus-graphql-core/test/schema/validation/schema-definition/fail/required query/no-query/response.json
@@ -1,6 +1,5 @@
 [
   {
-    "message": "Query root type must be provided.",
-    "locations": []
+    "message": "Query root type must be provided."
   }
 ]

--- a/morpheus-graphql-core/test/schema/validation/schema-definition/fail/required query/no-schema-no-query/response.json
+++ b/morpheus-graphql-core/test/schema/validation/schema-definition/fail/required query/no-schema-no-query/response.json
@@ -1,6 +1,5 @@
 [
   {
-    "message": "Query root type must be provided.",
-    "locations": []
+    "message": "Query root type must be provided."
   }
 ]

--- a/morpheus-graphql-core/test/schema/validation/schema-definition/fail/required query/schema-with-query/response.json
+++ b/morpheus-graphql-core/test/schema/validation/schema-definition/fail/required query/schema-with-query/response.json
@@ -1,6 +1,5 @@
 [
   {
-    "message": "Query root type must be provided.",
-    "locations": []
+    "message": "Query root type must be provided."
   }
 ]

--- a/morpheus-graphql-core/test/schema/validation/schema-definition/fail/unknown-type/unknown/response.json
+++ b/morpheus-graphql-core/test/schema/validation/schema-definition/fail/unknown-type/unknown/response.json
@@ -1,14 +1,11 @@
 [
   {
-    "message": "Unknown type \"MyType1\".",
-    "locations": []
+    "message": "Unknown type \"MyType1\"."
   },
   {
-    "message": "Unknown type \"Asfwe\".",
-    "locations": []
+    "message": "Unknown type \"Asfwe\"."
   },
   {
-    "message": "Unknown type \"GjsO\".",
-    "locations": []
+    "message": "Unknown type \"GjsO\"."
   }
 ]

--- a/test/Feature/Collision/category-collision-fail/response.json
+++ b/test/Feature/Collision/category-collision-fail/response.json
@@ -1,8 +1,7 @@
 {
   "errors": [
     {
-      "message": "It appears that the Haskell type \"Deity\" was used as both input and output type, which is not allowed by GraphQL specifications.\n\n If you supply \"typeNameModifier\" in \"GQLType.typeOptions\", you can override the default type names for \"Deity\" to solve this problem.",
-      "locations": []
+      "message": "It appears that the Haskell type \"Deity\" was used as both input and output type, which is not allowed by GraphQL specifications.\n\n If you supply \"typeNameModifier\" in \"GQLType.typeOptions\", you can override the default type names for \"Deity\" to solve this problem."
     }
   ]
 }

--- a/test/Feature/Collision/name-collision/response.json
+++ b/test/Feature/Collision/name-collision/response.json
@@ -1,12 +1,10 @@
 {
   "errors": [
     {
-      "message": "There can Be only One TypeDefinition Named \"A\".",
-      "locations": []
+      "message": "There can Be only One TypeDefinition Named \"A\"."
     },
     {
-      "message": "There can Be only One TypeDefinition Named \"A\".",
-      "locations": []
+      "message": "There can Be only One TypeDefinition Named \"A\"."
     }
   ]
 }

--- a/test/Feature/Inference/tagged-arguments-fail/introspection/response.json
+++ b/test/Feature/Inference/tagged-arguments-fail/introspection/response.json
@@ -1,8 +1,7 @@
 {
   "errors": [
     {
-      "message": "There can Be only One argument Named \"a2\"",
-      "locations": []
+      "message": "There can Be only One argument Named \"a2\""
     }
   ]
 }

--- a/test/Feature/Inference/tagged-arguments-fail/resolving/response.json
+++ b/test/Feature/Inference/tagged-arguments-fail/resolving/response.json
@@ -1,8 +1,7 @@
 {
   "errors": [
     {
-      "message": "There can Be only One argument Named \"a2\"",
-      "locations": []
+      "message": "There can Be only One argument Named \"a2\""
     }
   ]
 }


### PR DESCRIPTION
The [GraphQL Spec](https://spec.graphql.org/June2018/#sec-Errors) allows for omission of the locations value if it is appropriate, and common servers such as Hasura make use of this.

I think this should probably be tested too but am not sure where to fit it into the existing framework of tests - I'd appreciate it if someone more familiar with the repo could offer advice on this.