### PR TITLE
Export a function to add extensions to errors

### DIFF
--- a/morpheus-graphql-client/src/Data/Morpheus/Client/Declare/Aeson.hs
+++ b/morpheus-graphql-client/src/Data/Morpheus/Client/Declare/Aeson.hs
@@ -66,26 +66,54 @@ import Language.Haskell.TH
     Name,
     PatQ,
     Q,
+    Type (ConT),
     appE,
     conP,
     cxt,
     instanceD,
+    isInstance,
+    lookupTypeName,
     tupP,
-  )
+ )
+import Language.Haskell.TH.Syntax (Dec)
 import Relude hiding (toString)
 
-aesonDeclarations :: TypeKind -> [ClientTypeDefinition -> DecQ]
-aesonDeclarations KindEnum = [deriveFromJSON, deriveToJSON]
-aesonDeclarations KindScalar = deriveScalarJSON
-aesonDeclarations kind
-  | isResolverType kind = [deriveFromJSON]
-  | otherwise = [deriveToJSON]
+aesonDeclarations :: TypeKind -> ClientTypeDefinition -> Q [Dec]
+aesonDeclarations KindEnum clientDef = do
+    a <- deriveIfNotDefined deriveFromJSON ''FromJSON clientDef
+    b <- deriveIfNotDefined deriveToJSON ''ToJSON clientDef
+    pure (a <> b)
+aesonDeclarations KindScalar clientDef = deriveScalarJSON clientDef
+aesonDeclarations kind clientDef
+    | isResolverType kind = deriveIfNotDefined deriveFromJSON ''FromJSON clientDef
+    | otherwise = deriveIfNotDefined deriveToJSON ''ToJSON clientDef
+
+deriveIfNotDefined :: (ClientTypeDefinition -> Q Dec) -> Name -> ClientTypeDefinition -> Q [Dec]
+deriveIfNotDefined derivation typeClass clientDef = do
+    let name = mkTypeName clientDef
+    exists <- lookupTypeName (show name)
+    case exists of
+        Nothing -> mkDerivation
+        Just _ -> do
+            hasInstance <- isInstance typeClass [ConT name]
+            if hasInstance
+                then pure []
+                else mkDerivation
+  where
+    mkDerivation :: Q [Dec]
+    mkDerivation = do
+        derived <- derivation clientDef
+        pure [derived]
+
 
 failure :: GQLError -> Q a
 failure = fail . show
 
-deriveScalarJSON :: [ClientTypeDefinition -> DecQ]
-deriveScalarJSON = [deriveScalarFromJSON, deriveScalarToJSON]
+deriveScalarJSON :: ClientTypeDefinition -> Q [Dec]
+deriveScalarJSON clientDef = do
+    a <- deriveIfNotDefined deriveScalarFromJSON ''FromJSON clientDef
+    b <- deriveIfNotDefined deriveScalarToJSON ''ToJSON clientDef
+    pure (a <> b)
 
 deriveScalarFromJSON :: ClientTypeDefinition -> DecQ
 deriveScalarFromJSON ClientTypeDefinition {clientTypeName} =
@@ -224,7 +252,7 @@ deriveToJSON
           body =
             pure $
               AppE
-                (VarE 'object)
+                (VarE 'omitNulls)
                 (mkFieldsE typename '(.=) cFields)
 deriveToJSON
   ClientTypeDefinition
@@ -236,3 +264,15 @@ deriveToJSON
     where
       typeDef = applyCons ''ToJSON [typename]
       body = [funDSimple 'toJSON [] (aesonToJSONEnumBody clientTypeName clientCons)]
+
+omitNulls :: [(Text, Value)] -> Value
+omitNulls = object . filter notNull
+  where
+    notNull (_, Null) = False
+    notNull _ = True
+
+mkTypeName :: ClientTypeDefinition -> Name
+mkTypeName ClientTypeDefinition{clientTypeName = TypeNameTH namespace typeName} =
+    toType typeName
+  where
+    toType = toName . camelCaseTypeName namespace

--- a/morpheus-graphql-client/src/Data/Morpheus/Client/Declare/Client.hs
+++ b/morpheus-graphql-client/src/Data/Morpheus/Client/Declare/Client.hs
@@ -38,11 +38,10 @@ declareClient src ClientDefinition {clientArguments, clientTypes = rootType : su
     <*> (concat <$> traverse declareType subTypes)
 
 declareType :: ClientTypeDefinition -> Q [Dec]
-declareType clientType@ClientTypeDefinition {clientKind} =
-  apply clientType (typeDeclarations clientKind <> aesonDeclarations clientKind)
-
-apply :: Applicative f => a -> [a -> f b] -> f [b]
-apply a = traverse (\f -> f a)
+declareType clientType@ClientTypeDefinition{clientKind} = do
+    types <- typeDeclarations clientKind clientType
+    instances <- aesonDeclarations clientKind clientType
+    pure (types <> instances)
 
 queryArgumentType :: Maybe ClientTypeDefinition -> (Type, Q [Dec])
 queryArgumentType Nothing = (toCon ("()" :: String), pure [])

--- a/morpheus-graphql-client/src/Data/Morpheus/Client/Declare/Type.hs
+++ b/morpheus-graphql-client/src/Data/Morpheus/Client/Declare/Type.hs
@@ -35,9 +35,14 @@ import Data.Morpheus.Types.Internal.AST
 import Language.Haskell.TH
 import Relude hiding (Type)
 
-typeDeclarations :: TypeKind -> [ClientTypeDefinition -> Q Dec]
-typeDeclarations KindScalar = []
-typeDeclarations _ = [pure . declareType]
+typeDeclarations :: TypeKind -> ClientTypeDefinition -> Q [Dec]
+typeDeclarations KindScalar _ = pure []
+typeDeclarations _ c@ClientTypeDefinition{clientTypeName = TypeNameTH{namespace, typename}} = do
+    let name = mkConName namespace typename
+    m <- lookupTypeName (show name)
+    case m of
+        Nothing -> pure [declareType c]
+        _ -> pure []
 
 declareType :: ClientTypeDefinition -> Dec
 declareType

--- a/morpheus-graphql-core/src/Data/Morpheus/Types/Internal/AST.hs
+++ b/morpheus-graphql-core/src/Data/Morpheus/Types/Internal/AST.hs
@@ -149,6 +149,7 @@ module Data.Morpheus.Types.Internal.AST
     lookupDataType,
     Name,
     withPath,
+    withExtensions,
   )
 where
 

--- a/morpheus-graphql-core/src/Data/Morpheus/Types/Internal/AST/Error.hs
+++ b/morpheus-graphql-core/src/Data/Morpheus/Types/Internal/AST/Error.hs
@@ -65,7 +65,7 @@ atPositions GQLError {..} pos = case toList pos of
 
 
 withExtensions :: GQLError -> Map Text Value -> GQLError
-withExtensions gqlerr new_map = gqlerr { extensions = new_map }
+withExtensions gqlerr new_map = gqlerr { extensions = Just new_map }
 
 withPath :: GQLError -> [Text] -> GQLError
 withPath err [] = err

--- a/morpheus-graphql-core/src/Data/Morpheus/Types/Internal/AST/Error.hs
+++ b/morpheus-graphql-core/src/Data/Morpheus/Types/Internal/AST/Error.hs
@@ -22,6 +22,7 @@ module Data.Morpheus.Types.Internal.AST.Error
     Msg (..),
     Message,
     withPath,
+    withExtensions,
   )
 where
 
@@ -97,6 +98,9 @@ data GQLError = GQLError
       Generic,
       FromJSON
     )
+
+withExtensions :: GQLError -> (Maybe (Map Text Value) -> Maybe (Map Text Value)) -> GQLError
+withExtensions gqlerr f = gqlerr { extensions = f (extensions gqlerr) }
 
 instance Ord GQLError where
   compare x y = compare (locations x) (locations y) <> compare (message x) (message y)

--- a/morpheus-graphql-core/src/Data/Morpheus/Types/Internal/AST/Error.hs
+++ b/morpheus-graphql-core/src/Data/Morpheus/Types/Internal/AST/Error.hs
@@ -63,6 +63,10 @@ atPositions GQLError {..} pos = case toList pos of
   posList -> GQLError {locations = locations <> Just posList, ..}
 {-# INLINE atPositions #-}
 
+
+withExtensions :: GQLError -> Map Text Value -> GQLError
+withExtensions gqlerr new_map = gqlerr { extensions = new_map }
+
 withPath :: GQLError -> [Text] -> GQLError
 withPath err [] = err
 withPath err path = err {path = Just path}
@@ -98,9 +102,6 @@ data GQLError = GQLError
       Generic,
       FromJSON
     )
-
-withExtensions :: GQLError -> (Maybe (Map Text Value) -> Maybe (Map Text Value)) -> GQLError
-withExtensions gqlerr f = gqlerr { extensions = f (extensions gqlerr) }
 
 instance Ord GQLError where
   compare x y = compare (locations x) (locations y) <> compare (message x) (message y)

--- a/morpheus-graphql-core/src/Data/Morpheus/Types/Internal/AST/Error.hs
+++ b/morpheus-graphql-core/src/Data/Morpheus/Types/Internal/AST/Error.hs
@@ -65,7 +65,7 @@ atPositions GQLError {..} pos = case toList pos of
 
 
 withExtensions :: GQLError -> Map Text Value -> GQLError
-withExtensions gqlerr new_map = gqlerr { extensions = Just new_map }
+withExtensions gqlerr ext = gqlerr { extensions = Just ext }
 
 withPath :: GQLError -> [Text] -> GQLError
 withPath err [] = err

--- a/morpheus-graphql/src/Data/Morpheus/Server/TH/Declare/GQLType.hs
+++ b/morpheus-graphql/src/Data/Morpheus/Server/TH/Declare/GQLType.hs
@@ -78,6 +78,7 @@ dropNamespaceOptions _ tName opt = opt {fieldLabelModifier = stripFieldNamespace
 
 deriveGQLType :: ServerTypeDefinition -> ServerDec [Dec]
 deriveGQLType ServerInterfaceDefinition {} = pure []
+deriveGQLType ServerTypeDefinition {tKind = KindScalar} = pure []
 deriveGQLType
   ServerTypeDefinition
     { tName,


### PR DESCRIPTION
It is possible to add a path to errors, but it was not possible to add extensions. This exports a function to do so