### PR TITLE
fix(client): avoid generating duplicated Aeson instances

### DIFF
--- a/morpheus-graphql-client/src/Data/Morpheus/Client/Declare/Aeson.hs
+++ b/morpheus-graphql-client/src/Data/Morpheus/Client/Declare/Aeson.hs
@@ -264,7 +264,7 @@ deriveToJSON
       typeDef = applyCons ''ToJSON [typename]
       body = [funDSimple 'toJSON [] (aesonToJSONEnumBody clientTypeName clientCons)]
 
-omitNulls :: [(Text, Value)] -> Value
+omitNulls :: [(Key, Value)] -> Value
 omitNulls = object . filter notNull
   where
     notNull (_, Null) = False

--- a/morpheus-graphql-client/src/Data/Morpheus/Client/Declare/Client.hs
+++ b/morpheus-graphql-client/src/Data/Morpheus/Client/Declare/Client.hs
@@ -38,11 +38,10 @@ declareClient src ClientDefinition {clientArguments, clientTypes = rootType : su
     <*> (concat <$> traverse declareType subTypes)
 
 declareType :: ClientTypeDefinition -> Q [Dec]
-declareType clientType@ClientTypeDefinition {clientKind} =
-  apply clientType (typeDeclarations clientKind <> aesonDeclarations clientKind)
-
-apply :: Applicative f => a -> [a -> f b] -> f [b]
-apply a = traverse (\f -> f a)
+declareType clientType@ClientTypeDefinition{clientKind} = do
+    types <- typeDeclarations clientKind clientType
+    instances <- aesonDeclarations clientKind clientType
+    pure (types <> instances)
 
 queryArgumentType :: Maybe ClientTypeDefinition -> (Type, Q [Dec])
 queryArgumentType Nothing = (toCon ("()" :: String), pure [])

--- a/morpheus-graphql-client/src/Data/Morpheus/Client/Declare/Type.hs
+++ b/morpheus-graphql-client/src/Data/Morpheus/Client/Declare/Type.hs
@@ -35,9 +35,14 @@ import Data.Morpheus.Types.Internal.AST
 import Language.Haskell.TH
 import Relude hiding (Type)
 
-typeDeclarations :: TypeKind -> [ClientTypeDefinition -> Q Dec]
-typeDeclarations KindScalar = []
-typeDeclarations _ = [pure . declareType]
+typeDeclarations :: TypeKind -> ClientTypeDefinition -> Q [Dec]
+typeDeclarations KindScalar _ = pure []
+typeDeclarations _ c@ClientTypeDefinition{clientTypeName = TypeNameTH{namespace, typename}} = do
+    let name = mkConName namespace typename
+    m <- lookupTypeName (show name)
+    case m of
+        Nothing -> pure [declareType c]
+        _ -> pure []
 
 declareType :: ClientTypeDefinition -> Dec
 declareType

--- a/morpheus-graphql-client/src/Data/Morpheus/Client/Declare/Type.hs
+++ b/morpheus-graphql-client/src/Data/Morpheus/Client/Declare/Type.hs
@@ -34,15 +34,15 @@ import Data.Morpheus.Types.Internal.AST
   )
 import Language.Haskell.TH
 import Relude hiding (Type)
+import Data.Morpheus.Client.Internal.TH (isTypeDeclared)
 
 typeDeclarations :: TypeKind -> ClientTypeDefinition -> Q [Dec]
 typeDeclarations KindScalar _ = pure []
-typeDeclarations _ c@ClientTypeDefinition{clientTypeName = TypeNameTH{namespace, typename}} = do
-    let name = mkConName namespace typename
-    m <- lookupTypeName (show name)
-    case m of
-        Nothing -> pure [declareType c]
-        _ -> pure []
+typeDeclarations _ c = do
+    exists <- isTypeDeclared c
+    if exists
+        then pure []
+        else pure [declareType c]
 
 declareType :: ClientTypeDefinition -> Dec
 declareType


### PR DESCRIPTION
When generating the code for different queries that share the same
schema, morphreus tries to emit Aeson instances multiple times, which
does not work.

With this change, before generating a the instance, it will lookup
if it was declared already and avoid doing so.

This also helps when you want to take over and declare some things
manualy and let morpheus do the rest.

Additionally, this add a `omitNulls` pass to the generated Aeson object.
When sending the object for a type with lots of nullables, this reduces
significantly the request size.