### PR TITLE
Fix single variant enums

### DIFF
--- a/examples/code-gen/src/API/Posts/Resolver.hs
+++ b/examples/code-gen/src/API/Posts/Resolver.hs
@@ -14,13 +14,13 @@ resolvePost ::
   ID ->
   m (Maybe (Post m))
 resolvePost postId =
-  pure
-    $ Just
-    $ Post
-      { API.Posts.Posts.id = pure postId,
-        title = pure "Post Tittle",
-        authorID = pure "Post Author"
-      }
+  pure $
+    Just $
+      Post
+        { API.Posts.Posts.id = pure postId,
+          title = pure "Post Tittle",
+          authorID = pure "Post Author"
+        }
 
 resolveQuery :: Monad m => Query m
 resolveQuery =
@@ -38,12 +38,7 @@ resolveQuery =
 rootResolver ::
   Monad m =>
   RootResolver m () Query Undefined Undefined
-rootResolver =
-  RootResolver
-    { queryResolver = resolveQuery,
-      mutationResolver = Undefined,
-      subscriptionResolver = Undefined
-    }
+rootResolver = defaultRootResolver {queryResolver = resolveQuery}
 
 app :: (Typeable m, Monad m) => App () m
 app = deriveApp rootResolver

--- a/examples/code-gen/src/API/Users/Resolver.hs
+++ b/examples/code-gen/src/API/Users/Resolver.hs
@@ -14,12 +14,12 @@ resolveUser ::
   ID ->
   m (Maybe (User m))
 resolveUser postId =
-  pure
-    $ Just
-    $ User
-      { API.Users.Users.id = pure postId,
-        name = pure "User Tittle"
-      }
+  pure $
+    Just $
+      User
+        { API.Users.Users.id = pure postId,
+          name = pure "User Tittle"
+        }
 
 resolveQuery :: Monad m => Query m
 resolveQuery =
@@ -37,12 +37,7 @@ resolveQuery =
 rootResolver ::
   Monad m =>
   RootResolver m () Query Undefined Undefined
-rootResolver =
-  RootResolver
-    { queryResolver = resolveQuery,
-      mutationResolver = Undefined,
-      subscriptionResolver = Undefined
-    }
+rootResolver = defaultRootResolver {queryResolver = resolveQuery}
 
 app :: (Typeable m, Monad m) => App () m
 app = deriveApp rootResolver

--- a/examples/scotty-freer-simple/src/API.hs
+++ b/examples/scotty-freer-simple/src/API.hs
@@ -1,30 +1,39 @@
-{-# LANGUAGE DataKinds             #-}
-{-# LANGUAGE DeriveGeneric         #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DuplicateRecordFields #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE NamedFieldPuns        #-}
-{-# LANGUAGE OverloadedStrings     #-}
-{-# LANGUAGE ScopedTypeVariables   #-}
-{-# LANGUAGE TemplateHaskell       #-}
-{-# LANGUAGE TypeFamilies          #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module API (api) where
 
-import           Control.Monad.Freer        (Eff, Member)
-import           Data.ByteString.Lazy.Char8 (ByteString)
-import           Data.FileEmbed             (makeRelativeToProject)
-import           Data.Morpheus              (interpreter)
-import           Data.Morpheus.Document     (importGQLDocument)
-import           Data.Morpheus.Types        (Arg (Arg), RootResolver (..),
-                                             Undefined (..), liftEither)
-import           Data.Text                  (Text)
-import           Data.Typeable              (Typeable)
-import qualified DeityRepo                  as DR (DeityRepo, Error,
-                                                   createDeity, getDeityByName)
-import           Prelude                    hiding (error)
-import qualified Types                      as T
+import Control.Monad.Freer (Eff, Member)
+import Data.ByteString.Lazy.Char8 (ByteString)
+import Data.FileEmbed (makeRelativeToProject)
+import Data.Morpheus (interpreter)
+import Data.Morpheus.Document (importGQLDocument)
+import Data.Morpheus.Types
+  ( Arg (Arg),
+    RootResolver (..),
+    Undefined,
+    defaultRootResolver,
+    liftEither,
+  )
+import Data.Text (Text)
+import Data.Typeable (Typeable)
+import qualified DeityRepo as DR
+  ( DeityRepo,
+    Error,
+    createDeity,
+    getDeityByName,
+  )
+import qualified Types as T
+import Prelude hiding (error)
 
 importGQLDocument =<< makeRelativeToProject "src/api.gql"
 
@@ -33,23 +42,23 @@ api = interpreter rootResolver
 
 rootResolver :: Member DR.DeityRepo effs => RootResolver (Eff effs) () Query Mutation Undefined
 rootResolver =
-  RootResolver
+  defaultRootResolver
     { queryResolver = Query {deity = deityResolver},
-      mutationResolver = Mutation {createDeity = createDeityResolver},
-      subscriptionResolver = Undefined
+      mutationResolver = Mutation {createDeity = createDeityResolver}
     }
   where
     deityResolver (Arg name) =
       liftEither $ toResponse <$> DR.getDeityByName name
 
-    createDeityResolver CreateDeityArgs {name, power}=
+    createDeityResolver CreateDeityArgs {name, power} =
       liftEither $ toResponse <$> DR.createDeity (T.Deity name power)
 
-toResponse
-  :: (Applicative m)
-  => Either DR.Error T.Deity -> Either String (Deity m)
+toResponse ::
+  (Applicative m) =>
+  Either DR.Error T.Deity ->
+  Either String (Deity m)
 toResponse (Right deity) = Right $ toResponse' deity
-toResponse (Left error)  = Left $ show error
+toResponse (Left error) = Left $ show error
 
 toResponse' :: Applicative m => T.Deity -> Deity m
-toResponse' (T.Deity name power) = Deity { name = pure name, power = pure power }
+toResponse' (T.Deity name power) = Deity {name = pure name, power = pure power}

--- a/examples/scotty/src/Server/Fraxl/API.hs
+++ b/examples/scotty/src/Server/Fraxl/API.hs
@@ -28,7 +28,8 @@ import Data.Morpheus.Server
 import Data.Morpheus.Types
   ( GQLType,
     RootResolver (..),
-    Undefined (..),
+    Undefined,
+    defaultRootResolver,
     render,
   )
 import Data.Set (Set, singleton)
@@ -207,10 +208,8 @@ resolveInstruments = lift (dataFetch GetInstruments) >>= sequenceA . (resolveIns
 
 rootResolver :: (Monad m) => RootResolver (FreerT Source m) () Query Undefined Undefined
 rootResolver =
-  RootResolver
-    { queryResolver = Query {instruments = resolveInstruments},
-      mutationResolver = Undefined,
-      subscriptionResolver = Undefined
+  defaultRootResolver
+    { queryResolver = Query {instruments = resolveInstruments}
     }
 
 app :: App () (FreerT Source DB.Query)

--- a/examples/scotty/src/Server/Haxl/API.hs
+++ b/examples/scotty/src/Server/Haxl/API.hs
@@ -26,7 +26,8 @@ import Data.Morpheus.Types
     Resolver,
     ResolverQ,
     RootResolver (..),
-    Undefined (..),
+    Undefined,
+    defaultRootResolver,
     lift,
     render,
   )
@@ -87,12 +88,7 @@ resolveQuery =
     }
 
 rootResolver :: RootResolver Haxl () Query Undefined Undefined
-rootResolver =
-  RootResolver
-    { queryResolver = resolveQuery,
-      mutationResolver = Undefined,
-      subscriptionResolver = Undefined
-    }
+rootResolver = defaultRootResolver {queryResolver = resolveQuery}
 
 app :: App () Haxl
 app = deriveApp rootResolver

--- a/examples/scotty/src/Server/Mythology/API.hs
+++ b/examples/scotty/src/Server/Mythology/API.hs
@@ -17,7 +17,8 @@ import Data.Morpheus.Types
   ( GQLType,
     ResolverQ,
     RootResolver (..),
-    Undefined (..),
+    Undefined,
+    defaultRootResolver,
     liftEither,
   )
 import Data.Text (Text)
@@ -36,7 +37,7 @@ import Server.Mythology.Place (City)
 data Character m
   = CharacterHuman (Human m) -- Only <tyconName><conName> should generate direct link
   | CharacterDeity Deity -- Only <tyconName><conName> should generate direct link
-      -- RECORDS
+  -- RECORDS
   | Creature {name :: Text, age :: Int}
   | BoxedDeity {boxedDeity :: Deity}
   | SomeScalarRecord {scalar :: Text}
@@ -83,15 +84,13 @@ resolveCharacter =
 
 rootResolver :: RootResolver IO () Query Undefined Undefined
 rootResolver =
-  RootResolver
+  defaultRootResolver
     { queryResolver =
         Query
           { deity = resolveDeity,
             character = resolveCharacter,
             persons = resolvePersons
-          },
-      mutationResolver = Undefined,
-      subscriptionResolver = Undefined
+          }
     }
 
 app :: App () IO

--- a/examples/scotty/src/Server/Subscription/SimpleSubscription.hs
+++ b/examples/scotty/src/Server/Subscription/SimpleSubscription.hs
@@ -6,6 +6,7 @@
 
 module Server.Subscription.SimpleSubscription where
 
+import Data.Kind (Type)
 import Data.Morpheus.Subscriptions (Event (..))
 import Data.Morpheus.Types
   ( Resolver,

--- a/examples/scotty/src/Server/Subscription/SimpleSubscription.hs
+++ b/examples/scotty/src/Server/Subscription/SimpleSubscription.hs
@@ -42,7 +42,7 @@ newtype Mutation m = Mutation
   }
   deriving (Generic)
 
-newtype Subscription (m :: * -> *) = Subscription
+newtype Subscription (m :: Type -> Type) = Subscription
   { newDeity :: SubscriptionField (m Deity)
   }
   deriving (Generic)
@@ -68,7 +68,7 @@ rootResolver =
         subResolver (Event [ChannelA] (ContentA _value)) = fetchDeity -- resolve New State
         subResolver (Event [ChannelA] (ContentB _value)) = fetchDeity -- resolve New State
         subResolver _ = fetchDeity -- Resolve Old State
-          ---------------------------------------------------------
+        ---------------------------------------------------------
     fetchDeity :: Applicative m => m Deity
     fetchDeity = pure someDeity
 

--- a/examples/scotty/src/Server/TH/Simple.hs
+++ b/examples/scotty/src/Server/TH/Simple.hs
@@ -29,7 +29,10 @@ import Data.Text (Text)
 importGQLDocument =<< makeRelativeToProject "src/Server/TH/simple.gql"
 
 rootResolver :: RootResolver IO () Query Undefined Undefined
-rootResolver = defaultRootResolver {queryResolver = Query {deity}}
+rootResolver =
+  defaultRootResolver
+    { queryResolver = Query {deity}
+    }
   where
     deity (Arg name) =
       pure

--- a/examples/scotty/src/Server/TH/Simple.hs
+++ b/examples/scotty/src/Server/TH/Simple.hs
@@ -18,18 +18,18 @@ where
 import Data.FileEmbed (makeRelativeToProject)
 import Data.Morpheus (App, deriveApp)
 import Data.Morpheus.Document (importGQLDocument)
-import Data.Morpheus.Types (Arg (Arg), RootResolver (..), Undefined (..))
+import Data.Morpheus.Types
+  ( Arg (..),
+    RootResolver (..),
+    Undefined,
+    defaultRootResolver,
+  )
 import Data.Text (Text)
 
 importGQLDocument =<< makeRelativeToProject "src/Server/TH/simple.gql"
 
 rootResolver :: RootResolver IO () Query Undefined Undefined
-rootResolver =
-  RootResolver
-    { queryResolver = Query {deity},
-      mutationResolver = Undefined,
-      subscriptionResolver = Undefined
-    }
+rootResolver = defaultRootResolver {queryResolver = Query {deity}}
   where
     deity (Arg name) =
       pure

--- a/examples/subscription-extpubsub/src/Server.hs
+++ b/examples/subscription-extpubsub/src/Server.hs
@@ -27,7 +27,8 @@ import Data.Morpheus.Types
     Resolver,
     RootResolver (..),
     SUBSCRIPTION,
-    Undefined (Undefined),
+    Undefined,
+    defaultRootResolver,
     subscribe,
   )
 import Data.Text (Text)
@@ -76,9 +77,9 @@ scottyServer = do
   where
     settings portNumber = Warp.setPort portNumber Warp.defaultSettings
     app publish =
-      scottyApp
-        $ post "/api"
-        $ raw =<< (liftIO . httpPubApp makeApp publish) =<< body
+      scottyApp $
+        post "/api" $
+          raw =<< (liftIO . httpPubApp makeApp publish) =<< body
 
 data EventChannel = PgChannel | RBMQChannel
   deriving (Eq, Show)
@@ -90,9 +91,8 @@ type AppEvent = Event EventChannel EventContent
 
 rootResolver :: RootResolver IO AppEvent Query Undefined Subscription
 rootResolver =
-  RootResolver
+  defaultRootResolver
     { queryResolver = queryInstance,
-      mutationResolver = Undefined,
       subscriptionResolver = subscriptionInstance
     }
 

--- a/morpheus-graphql-client/src/Data/Morpheus/Client/Fetch.hs
+++ b/morpheus-graphql-client/src/Data/Morpheus/Client/Fetch.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE ConstrainedClassMethods #-}
-{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
@@ -44,7 +43,16 @@ import Data.Text
   ( pack,
   )
 import Language.Haskell.TH
-import Relude hiding (ByteString, Type)
+  ( Dec,
+    Q,
+    clause,
+    cxt,
+    funD,
+    instanceD,
+    normalB,
+  )
+import qualified Language.Haskell.TH as TH
+import Relude hiding (ByteString)
 
 fixVars :: A.Value -> Maybe A.Value
 fixVars x
@@ -69,7 +77,7 @@ class Fetch a where
       processResponse JSONResponse {responseData = result, responseErrors = (x : xs)} = Left $ FetchErrorProducedErrors (x :| xs) result
   fetch :: (Monad m, FromJSON a) => (ByteString -> m ByteString) -> Args a -> m (Either (FetchError a) a)
 
-deriveFetch :: Type -> TypeName -> String -> Q [Dec]
+deriveFetch :: TH.Type -> TypeName -> String -> Q [Dec]
 deriveFetch resultType typeName queryString =
   pure <$> instanceD (cxt []) iHead methods
   where

--- a/morpheus-graphql-client/src/Data/Morpheus/Client/Fetch.hs
+++ b/morpheus-graphql-client/src/Data/Morpheus/Client/Fetch.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE ConstrainedClassMethods #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}

--- a/morpheus-graphql-client/src/Data/Morpheus/Client/Fetch.hs
+++ b/morpheus-graphql-client/src/Data/Morpheus/Client/Fetch.hs
@@ -51,7 +51,7 @@ fixVars x
   | otherwise = Just x
 
 class Fetch a where
-  type Args a :: *
+  type Args a :: Type
   __fetch ::
     (Monad m, Show a, ToJSON (Args a), FromJSON a) =>
     String ->

--- a/morpheus-graphql/morpheus-graphql.cabal
+++ b/morpheus-graphql/morpheus-graphql.cabal
@@ -112,6 +112,8 @@ data-files:
     test/Feature/Holistic/holistic/selection/unknownField/query.gql
     test/Feature/Holistic/schema-ext.gql
     test/Feature/Holistic/schema.gql
+    test/Feature/Inference/object-and-enum/introspection/query.gql
+    test/Feature/Inference/object-and-enum/resolving/query.gql
     test/Feature/Inference/tagged-arguments-fail/introspection/query.gql
     test/Feature/Inference/tagged-arguments-fail/resolving/query.gql
     test/Feature/Inference/tagged-arguments/introspection/query.gql
@@ -322,6 +324,8 @@ data-files:
     test/Feature/Holistic/holistic/selection/subscription/singleTopLevelField/fail/response.json
     test/Feature/Holistic/holistic/selection/subscription/singleTopLevelField/failAnonymous/response.json
     test/Feature/Holistic/holistic/selection/unknownField/response.json
+    test/Feature/Inference/object-and-enum/introspection/response.json
+    test/Feature/Inference/object-and-enum/resolving/response.json
     test/Feature/Inference/tagged-arguments-fail/introspection/response.json
     test/Feature/Inference/tagged-arguments-fail/resolving/response.json
     test/Feature/Inference/tagged-arguments/introspection/response.json
@@ -523,6 +527,7 @@ test-suite morpheus-graphql-test
       Feature.Collision.NameCollision
       Feature.Collision.NameCollisionHelper
       Feature.Holistic.API
+      Feature.Inference.ObjectAndEnum
       Feature.Inference.TaggedArguments
       Feature.Inference.TaggedArgumentsFail
       Feature.Inference.TypeGuards

--- a/morpheus-graphql/src/Data/Morpheus/Server/Deriving/Schema/TypeContent.hs
+++ b/morpheus-graphql/src/Data/Morpheus/Server/Deriving/Schema/TypeContent.hs
@@ -25,7 +25,7 @@ import Data.Morpheus.Server.Deriving.Utils
 import Data.Morpheus.Server.Deriving.Utils.Kinded
   ( CategoryValue (..),
   )
-import Data.Morpheus.Server.Types.GQLType (GQLType)
+import Data.Morpheus.Server.Types.GQLType (GQLType (__isEmptyType))
 import Data.Morpheus.Server.Types.SchemaT (SchemaT)
 import Data.Morpheus.Types.Internal.AST
 
@@ -34,6 +34,6 @@ buildTypeContent ::
   KindedType kind a ->
   [ConsRep (TyContent kind)] ->
   SchemaT kind (TypeContent TRUE kind CONST)
+buildTypeContent scope cons | all isEmptyConstraint cons && not (__isEmptyType scope) = buildEnumTypeContent scope (consName <$> cons)
 buildTypeContent scope [ConsRep {consFields}] = buildObjectTypeContent scope consFields
-buildTypeContent scope cons | all isEmptyConstraint cons = buildEnumTypeContent scope (consName <$> cons)
 buildTypeContent scope cons = buildUnionTypeContent scope cons

--- a/morpheus-graphql/src/Data/Morpheus/Server/Deriving/Schema/TypeContent.hs
+++ b/morpheus-graphql/src/Data/Morpheus/Server/Deriving/Schema/TypeContent.hs
@@ -25,7 +25,7 @@ import Data.Morpheus.Server.Deriving.Utils
 import Data.Morpheus.Server.Deriving.Utils.Kinded
   ( CategoryValue (..),
   )
-import Data.Morpheus.Server.Types.GQLType (GQLType (__isEmptyType))
+import Data.Morpheus.Server.Types.GQLType (GQLType)
 import Data.Morpheus.Server.Types.SchemaT (SchemaT)
 import Data.Morpheus.Types.Internal.AST
 
@@ -34,6 +34,6 @@ buildTypeContent ::
   KindedType kind a ->
   [ConsRep (TyContent kind)] ->
   SchemaT kind (TypeContent TRUE kind CONST)
-buildTypeContent scope cons | all isEmptyConstraint cons && not (__isEmptyType scope) = buildEnumTypeContent scope (consName <$> cons)
+buildTypeContent scope cons | all isEmptyConstraint cons = buildEnumTypeContent scope (consName <$> cons)
 buildTypeContent scope [ConsRep {consFields}] = buildObjectTypeContent scope consFields
 buildTypeContent scope cons = buildUnionTypeContent scope cons

--- a/morpheus-graphql/src/Data/Morpheus/Server/Types/Types.hs
+++ b/morpheus-graphql/src/Data/Morpheus/Server/Types/Types.hs
@@ -16,11 +16,9 @@ import GHC.Generics
   ( Generic,
   )
 import GHC.TypeLits (Symbol)
-import Prelude
-  ( Show,
-  )
+import Prelude (Bool, Show)
 
-data Undefined (m :: Type -> Type) = Undefined deriving (Show, Generic)
+newtype Undefined (m :: Type -> Type) = Undefined Bool deriving (Show, Generic)
 
 data Pair k v = Pair k v deriving (Generic)
 

--- a/morpheus-graphql/src/Data/Morpheus/Types.hs
+++ b/morpheus-graphql/src/Data/Morpheus/Types.hs
@@ -23,7 +23,7 @@ module Data.Morpheus.Types
     RootResolver (..),
     constRes,
     constMutRes,
-    Undefined (..),
+    Undefined,
     Resolver,
     QUERY,
     MUTATION,
@@ -64,6 +64,7 @@ module Data.Morpheus.Types
     fieldLabelModifier,
     constructorTagModifier,
     typeNameModifier,
+    defaultRootResolver,
   )
 where
 
@@ -220,6 +221,14 @@ data
     mutationResolver :: mutation (Resolver MUTATION event m),
     subscriptionResolver :: subscription (Resolver SUBSCRIPTION event m)
   }
+
+defaultRootResolver :: RootResolver m event Undefined Undefined Undefined
+defaultRootResolver =
+  RootResolver
+    { queryResolver = Undefined False,
+      mutationResolver = Undefined False,
+      subscriptionResolver = Undefined False
+    }
 
 data
   NamedResolvers

--- a/morpheus-graphql/test/Feature/Collision/CategoryCollisionFail.hs
+++ b/morpheus-graphql/test/Feature/Collision/CategoryCollisionFail.hs
@@ -10,6 +10,7 @@ module Feature.Collision.CategoryCollisionFail
   )
 where
 
+import Data.Kind (Type)
 import Data.Morpheus (interpreter)
 import Data.Morpheus.Types
   ( GQLRequest,
@@ -35,7 +36,7 @@ newtype DeityArgs = DeityArgs
   }
   deriving (Show, Generic, GQLType)
 
-newtype Query (m :: * -> *) = Query
+newtype Query (m :: Type -> Type) = Query
   { deity :: DeityArgs -> m Deity
   }
   deriving (Generic, GQLType)

--- a/morpheus-graphql/test/Feature/Collision/CategoryCollisionFail.hs
+++ b/morpheus-graphql/test/Feature/Collision/CategoryCollisionFail.hs
@@ -16,7 +16,8 @@ import Data.Morpheus.Types
     GQLResponse,
     GQLType (..),
     RootResolver (..),
-    Undefined (..),
+    Undefined,
+    defaultRootResolver,
   )
 import Data.Text
   ( Text,
@@ -41,7 +42,7 @@ newtype Query (m :: * -> *) = Query
 
 rootResolver :: RootResolver IO () Query Undefined Undefined
 rootResolver =
-  RootResolver
+  defaultRootResolver
     { queryResolver =
         Query
           { deity =
@@ -52,9 +53,7 @@ rootResolver =
                         "Morpheus",
                       age = 1000
                     }
-          },
-      mutationResolver = Undefined,
-      subscriptionResolver = Undefined
+          }
     }
 
 api :: GQLRequest -> IO GQLResponse

--- a/morpheus-graphql/test/Feature/Collision/CategoryCollisionSuccess.hs
+++ b/morpheus-graphql/test/Feature/Collision/CategoryCollisionSuccess.hs
@@ -17,7 +17,7 @@ import Data.Morpheus.Types
     GQLType (..),
     GQLTypeOptions (..),
     RootResolver (..),
-    Undefined (..),
+    Undefined,
     defaultRootResolver,
   )
 import Data.Text

--- a/morpheus-graphql/test/Feature/Collision/CategoryCollisionSuccess.hs
+++ b/morpheus-graphql/test/Feature/Collision/CategoryCollisionSuccess.hs
@@ -9,6 +9,7 @@ module Feature.Collision.CategoryCollisionSuccess
   )
 where
 
+import Data.Kind (Type)
 import Data.Morpheus (interpreter)
 import Data.Morpheus.Types
   ( GQLRequest,
@@ -17,6 +18,7 @@ import Data.Morpheus.Types
     GQLTypeOptions (..),
     RootResolver (..),
     Undefined (..),
+    defaultRootResolver,
   )
 import Data.Text
   ( Text,
@@ -41,14 +43,14 @@ newtype DeityArgs = DeityArgs
   }
   deriving (Show, Generic, GQLType)
 
-newtype Query (m :: * -> *) = Query
+newtype Query (m :: Type -> Type) = Query
   { deity :: DeityArgs -> m Deity
   }
   deriving (Generic, GQLType)
 
 rootResolver :: RootResolver IO () Query Undefined Undefined
 rootResolver =
-  RootResolver
+  defaultRootResolver
     { queryResolver =
         Query
           { deity =
@@ -59,9 +61,7 @@ rootResolver =
                         "Morpheus",
                       age = 1000
                     }
-          },
-      mutationResolver = Undefined,
-      subscriptionResolver = Undefined
+          }
     }
 
 api :: GQLRequest -> IO GQLResponse

--- a/morpheus-graphql/test/Feature/Collision/NameCollision.hs
+++ b/morpheus-graphql/test/Feature/Collision/NameCollision.hs
@@ -8,8 +8,16 @@ module Feature.Collision.NameCollision
   )
 where
 
+import Data.Kind (Type)
 import Data.Morpheus (interpreter)
-import Data.Morpheus.Types (GQLRequest, GQLResponse, GQLType (..), RootResolver (..), Undefined (..))
+import Data.Morpheus.Types
+  ( GQLRequest,
+    GQLResponse,
+    GQLType (..),
+    RootResolver (..),
+    Undefined (..),
+    defaultRootResolver,
+  )
 import Data.Text (Text)
 import qualified Feature.Collision.NameCollisionHelper as A2 (A (..))
 import GHC.Generics (Generic)
@@ -20,7 +28,7 @@ data A = A
   }
   deriving (Generic, GQLType)
 
-data Query (m :: * -> *) = Query
+data Query (m :: Type -> Type) = Query
   { a1 :: A,
     a2 :: A2.A
   }
@@ -28,10 +36,8 @@ data Query (m :: * -> *) = Query
 
 rootResolver :: RootResolver IO () Query Undefined Undefined
 rootResolver =
-  RootResolver
-    { queryResolver = Query {a1 = A "" 0, a2 = A2.A 0},
-      mutationResolver = Undefined,
-      subscriptionResolver = Undefined
+  defaultRootResolver
+    { queryResolver = Query {a1 = A "" 0, a2 = A2.A 0}
     }
 
 api :: GQLRequest -> IO GQLResponse

--- a/morpheus-graphql/test/Feature/Collision/NameCollision.hs
+++ b/morpheus-graphql/test/Feature/Collision/NameCollision.hs
@@ -15,7 +15,7 @@ import Data.Morpheus.Types
     GQLResponse,
     GQLType (..),
     RootResolver (..),
-    Undefined (..),
+    Undefined,
     defaultRootResolver,
   )
 import Data.Text (Text)

--- a/morpheus-graphql/test/Feature/Holistic/API.hs
+++ b/morpheus-graphql/test/Feature/Holistic/API.hs
@@ -36,7 +36,7 @@ import Data.Morpheus.Types
     RootResolver (..),
     ScalarValue (..),
     TypeGuard (..),
-    Undefined (..),
+    Undefined,
     defaultRootResolver,
     liftEither,
     subscribe,

--- a/morpheus-graphql/test/Feature/Holistic/API.hs
+++ b/morpheus-graphql/test/Feature/Holistic/API.hs
@@ -37,6 +37,7 @@ import Data.Morpheus.Types
     ScalarValue (..),
     TypeGuard (..),
     Undefined (..),
+    defaultRootResolver,
     liftEither,
     subscribe,
   )
@@ -44,12 +45,7 @@ import Data.Semigroup ((<>))
 import Data.Text (Text)
 import GHC.Generics (Generic)
 import Prelude
-  ( ($),
-    (*),
-    (+),
-    (.),
-    (<$>),
-    Applicative (..),
+  ( Applicative (..),
     Either (..),
     Eq (..),
     IO,
@@ -58,6 +54,11 @@ import Prelude
     Show (..),
     String,
     const,
+    ($),
+    (*),
+    (+),
+    (.),
+    (<$>),
   )
 
 data TestScalar
@@ -145,15 +146,13 @@ root =
 
 rootExt :: RootResolver IO EVENT ExtQuery Undefined Undefined
 rootExt =
-  RootResolver
+  defaultRootResolver
     { queryResolver =
         ExtQuery
           { fail1 = liftEither alwaysFail,
             fail2 = fail "fail with MonadFail",
             type' = \(Arg TypeInput {data'}) -> pure data'
-          },
-      mutationResolver = Undefined,
-      subscriptionResolver = Undefined
+          }
     }
 
 api :: GQLRequest -> IO GQLResponse

--- a/morpheus-graphql/test/Feature/Inference/ObjectAndEnum.hs
+++ b/morpheus-graphql/test/Feature/Inference/ObjectAndEnum.hs
@@ -1,65 +1,43 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE TypeFamilies #-}
 
-module Feature.Inference.UnionType
+module Feature.Inference.ObjectAndEnum
   ( api,
   )
 where
 
+import Data.Kind (Type)
 import Data.Morpheus (interpreter)
 import Data.Morpheus.Types
   ( GQLRequest,
     GQLResponse,
     GQLType (..),
-    ResolverQ,
     RootResolver (..),
     Undefined (..),
   )
-import Data.Text (Text)
 import GHC.Generics (Generic)
 
-data A = A
-  { aText :: Text,
-    aInt :: Int
+data MyEnum = MyEnum deriving (Generic, GQLType)
+
+newtype MyObject
+  = MyObject Int
+  deriving (Generic, GQLType)
+
+data Query (m :: Type -> Type) = Query
+  { enum :: MyEnum,
+    object :: MyObject
   }
   deriving (Generic, GQLType)
-
-data B = B
-  { bText :: Text,
-    bInt :: Int
-  }
-  deriving (Generic, GQLType)
-
-data C = C
-  { cText :: Text,
-    cInt :: Int
-  }
-  deriving (Generic, GQLType)
-
-data Sum
-  = SumA A
-  | SumB B
-  deriving (Generic, GQLType)
-
-data Query m = Query
-  { union :: m [Sum],
-    fc :: C
-  }
-  deriving (Generic, GQLType)
-
-resolveUnion :: ResolverQ () IO [Sum]
-resolveUnion =
-  return [SumA A {aText = "at", aInt = 1}, SumB B {bText = "bt", bInt = 2}]
 
 rootResolver :: RootResolver IO () Query Undefined Undefined
 rootResolver =
   RootResolver
     { queryResolver =
         Query
-          { union = resolveUnion,
-            fc = C {cText = "", cInt = 3}
+          { enum = MyEnum,
+            object = MyObject 0
           },
       mutationResolver = Undefined,
       subscriptionResolver = Undefined

--- a/morpheus-graphql/test/Feature/Inference/ObjectAndEnum.hs
+++ b/morpheus-graphql/test/Feature/Inference/ObjectAndEnum.hs
@@ -15,7 +15,7 @@ import Data.Morpheus.Types
     GQLResponse,
     GQLType (..),
     RootResolver (..),
-    Undefined (..),
+    Undefined,
     defaultRootResolver,
   )
 import GHC.Generics (Generic)

--- a/morpheus-graphql/test/Feature/Inference/ObjectAndEnum.hs
+++ b/morpheus-graphql/test/Feature/Inference/ObjectAndEnum.hs
@@ -16,6 +16,7 @@ import Data.Morpheus.Types
     GQLType (..),
     RootResolver (..),
     Undefined (..),
+    defaultRootResolver,
   )
 import GHC.Generics (Generic)
 
@@ -31,17 +32,15 @@ data Query (m :: Type -> Type) = Query
   }
   deriving (Generic, GQLType)
 
-rootResolver :: RootResolver IO () Query Undefined Undefined
-rootResolver =
-  RootResolver
+root :: RootResolver IO () Query Undefined Undefined
+root =
+  defaultRootResolver
     { queryResolver =
         Query
           { enum = MyEnum,
             object = MyObject 0
-          },
-      mutationResolver = Undefined,
-      subscriptionResolver = Undefined
+          }
     }
 
 api :: GQLRequest -> IO GQLResponse
-api = interpreter rootResolver
+api = interpreter root

--- a/morpheus-graphql/test/Feature/Inference/TaggedArguments.hs
+++ b/morpheus-graphql/test/Feature/Inference/TaggedArguments.hs
@@ -9,6 +9,7 @@ module Feature.Inference.TaggedArguments
   )
 where
 
+import Data.Kind (Type)
 import Data.Morpheus (interpreter)
 import Data.Morpheus.Types
   ( Arg (..),
@@ -16,7 +17,8 @@ import Data.Morpheus.Types
     GQLResponse,
     GQLType (..),
     RootResolver (..),
-    Undefined (..),
+    Undefined,
+    defaultRootResolver,
   )
 import Data.Text
   ( Text,
@@ -28,33 +30,46 @@ data A = A
   { a1 :: Text,
     a2 :: Int
   }
-  deriving (Show, Generic, GQLType)
+  deriving
+    ( Show,
+      Generic,
+      GQLType
+    )
 
 newtype B = B
   {b1 :: Text}
-  deriving (Show, Generic, GQLType)
+  deriving
+    ( Show,
+      Generic,
+      GQLType
+    )
 
 newtype C = C
   {c1 :: Int}
-  deriving (Show, Generic, GQLType)
+  deriving
+    ( Show,
+      Generic,
+      GQLType
+    )
 
-data Query (m :: * -> *) = Query
+data Query (m :: Type -> Type) = Query
   { field1 :: A -> B -> C -> m Text,
     field2 :: A -> Arg "b1" Text -> Arg "c1" Int -> m Text
   }
-  deriving (Generic, GQLType)
+  deriving
+    ( Generic,
+      GQLType
+    )
 
-rootResolver :: RootResolver IO () Query Undefined Undefined
-rootResolver =
-  RootResolver
+root :: RootResolver IO () Query Undefined Undefined
+root =
+  defaultRootResolver
     { queryResolver =
         Query
           { field1 = \a b c -> pure $ pack $ show (a, b, c),
             field2 = \a b c -> pure $ pack $ show (a, b, c)
-          },
-      mutationResolver = Undefined,
-      subscriptionResolver = Undefined
+          }
     }
 
 api :: GQLRequest -> IO GQLResponse
-api = interpreter rootResolver
+api = interpreter root

--- a/morpheus-graphql/test/Feature/Inference/TaggedArgumentsFail.hs
+++ b/morpheus-graphql/test/Feature/Inference/TaggedArgumentsFail.hs
@@ -9,13 +9,14 @@ module Feature.Inference.TaggedArgumentsFail
   )
 where
 
+import Data.Kind (Type)
 import Data.Morpheus (interpreter)
 import Data.Morpheus.Types
   ( GQLRequest,
     GQLResponse,
     GQLType (..),
     RootResolver (..),
-    Undefined (..),
+    Undefined,
     defaultRootResolver,
   )
 import Data.Text
@@ -34,7 +35,7 @@ newtype B = B
   {a2 :: Text}
   deriving (Show, Generic, GQLType)
 
-newtype Query (m :: * -> *) = Query
+newtype Query (m :: Type -> Type) = Query
   { field1 :: A -> B -> m Text
   }
   deriving (Generic, GQLType)

--- a/morpheus-graphql/test/Feature/Inference/TaggedArgumentsFail.hs
+++ b/morpheus-graphql/test/Feature/Inference/TaggedArgumentsFail.hs
@@ -16,6 +16,7 @@ import Data.Morpheus.Types
     GQLType (..),
     RootResolver (..),
     Undefined (..),
+    defaultRootResolver,
   )
 import Data.Text
   ( Text,
@@ -40,13 +41,11 @@ newtype Query (m :: * -> *) = Query
 
 rootResolver :: RootResolver IO () Query Undefined Undefined
 rootResolver =
-  RootResolver
+  defaultRootResolver
     { queryResolver =
         Query
           { field1 = \a b -> pure $ pack $ show (a, b)
-          },
-      mutationResolver = Undefined,
-      subscriptionResolver = Undefined
+          }
     }
 
 api :: GQLRequest -> IO GQLResponse

--- a/morpheus-graphql/test/Feature/Inference/TypeGuards.hs
+++ b/morpheus-graphql/test/Feature/Inference/TypeGuards.hs
@@ -18,6 +18,7 @@ import Data.Morpheus.Types
     RootResolver (..),
     TypeGuard (..),
     Undefined (..),
+    defaultRootResolver,
   )
 import Data.Text
   ( Text,
@@ -67,13 +68,8 @@ resolveCharacters =
 
 rootResolver :: RootResolver IO () Query Undefined Undefined
 rootResolver =
-  RootResolver
-    { queryResolver =
-        Query
-          { characters = resolveCharacters
-          },
-      mutationResolver = Undefined,
-      subscriptionResolver = Undefined
+  defaultRootResolver
+    { queryResolver = Query {characters = resolveCharacters}
     }
 
 api :: GQLRequest -> IO GQLResponse

--- a/morpheus-graphql/test/Feature/Inference/TypeGuards.hs
+++ b/morpheus-graphql/test/Feature/Inference/TypeGuards.hs
@@ -10,6 +10,7 @@ module Feature.Inference.TypeGuards
   )
 where
 
+import Data.Kind (Type)
 import Data.Morpheus (interpreter)
 import Data.Morpheus.Types
   ( GQLRequest,
@@ -17,7 +18,7 @@ import Data.Morpheus.Types
     GQLType (..),
     RootResolver (..),
     TypeGuard (..),
-    Undefined (..),
+    Undefined,
     defaultRootResolver,
   )
 import Data.Text
@@ -31,21 +32,21 @@ data Character = Hydra
   }
   deriving (Show, Generic, GQLType)
 
-data Deity (m :: * -> *) = Deity
+data Deity (m :: Type -> Type) = Deity
   { name :: Text,
     age :: Int,
     power :: Text
   }
   deriving (Generic, GQLType)
 
-data Implements (m :: * -> *)
+data Implements (m :: Type -> Type)
   = ImplementsDeity (Deity m)
   | Creature {name :: Text, age :: Int}
   deriving (Generic, GQLType)
 
 type Characters m = TypeGuard Character (Implements m)
 
-newtype Query (m :: * -> *) = Query
+newtype Query (m :: Type -> Type) = Query
   { characters :: [Characters m]
   }
   deriving (Generic, GQLType)

--- a/morpheus-graphql/test/Feature/Inference/TypeInference.hs
+++ b/morpheus-graphql/test/Feature/Inference/TypeInference.hs
@@ -10,6 +10,7 @@ module Feature.Inference.TypeInference
   )
 where
 
+import Data.Kind (Type)
 import Data.Morpheus (interpreter)
 import Data.Morpheus.Types
   ( GQLRequest,
@@ -31,7 +32,7 @@ data Power
   | Hurricanes
   deriving (Generic, GQLType)
 
-data Deity (m :: * -> *) = Deity
+data Deity (m :: Type -> Type) = Deity
   { name :: Text,
     power :: Power
   }
@@ -52,7 +53,7 @@ data Monster
   | UnidentifiedMonster
   deriving (Show, Generic, GQLType)
 
-data Character (m :: * -> *)
+data Character (m :: Type -> Type)
   = CharacterDeity (Deity m) -- Only <tyCon name><type ref name> should generate direct link
   | Creature {creatureName :: Text, creatureAge :: Int}
   | BoxedDeity {boxedDeity :: Deity m}
@@ -82,7 +83,7 @@ newtype MonsterArgs = MonsterArgs
   }
   deriving (Show, Generic, GQLType)
 
-data Query (m :: * -> *) = Query
+data Query (m :: Type -> Type) = Query
   { deity :: Deity m,
     character :: [Character m],
     showMonster :: MonsterArgs -> m Text

--- a/morpheus-graphql/test/Feature/Inference/TypeInference.hs
+++ b/morpheus-graphql/test/Feature/Inference/TypeInference.hs
@@ -16,7 +16,8 @@ import Data.Morpheus.Types
     GQLResponse,
     GQLType (..),
     RootResolver (..),
-    Undefined (..),
+    Undefined,
+    defaultRootResolver,
   )
 import Data.Text
   ( Text,
@@ -90,15 +91,13 @@ data Query (m :: * -> *) = Query
 
 rootResolver :: RootResolver IO () Query Undefined Undefined
 rootResolver =
-  RootResolver
+  defaultRootResolver
     { queryResolver =
         Query
           { deity = deityRes,
             character = resolveCharacter,
             showMonster
-          },
-      mutationResolver = Undefined,
-      subscriptionResolver = Undefined
+          }
     }
   where
     showMonster MonsterArgs {monster} = pure (pack $ show monster)

--- a/morpheus-graphql/test/Feature/Inference/UnionType.hs
+++ b/morpheus-graphql/test/Feature/Inference/UnionType.hs
@@ -15,7 +15,8 @@ import Data.Morpheus.Types
     GQLType (..),
     ResolverQ,
     RootResolver (..),
-    Undefined (..),
+    Undefined,
+    defaultRootResolver,
   )
 import Data.Text (Text)
 import GHC.Generics (Generic)
@@ -55,14 +56,12 @@ resolveUnion =
 
 rootResolver :: RootResolver IO () Query Undefined Undefined
 rootResolver =
-  RootResolver
+  defaultRootResolver
     { queryResolver =
         Query
           { union = resolveUnion,
             fc = C {cText = "", cInt = 3}
-          },
-      mutationResolver = Undefined,
-      subscriptionResolver = Undefined
+          }
     }
 
 api :: GQLRequest -> IO GQLResponse

--- a/morpheus-graphql/test/Feature/Inference/WrappedType.hs
+++ b/morpheus-graphql/test/Feature/Inference/WrappedType.hs
@@ -29,7 +29,7 @@ data Wrapped a b = Wrapped
   deriving (Generic, GQLType)
 
 data WA m = WA
-  { aText :: () -> m Text,
+  { aText :: m Text,
     aInt :: Int
   }
   deriving (Generic, GQLType)
@@ -58,7 +58,7 @@ data Channel
 
 type EVENT = Event Channel ()
 
-data Subscription (m :: * -> *) = Subscription
+data Subscription (m :: Type -> Type) = Subscription
   { sub1 :: SubscriptionField (m (Maybe (WA m))),
     sub2 :: SubscriptionField (m (Maybe Wrapped1)),
     sub3 :: SubscriptionField (m (Maybe Wrapped2))
@@ -68,7 +68,7 @@ data Subscription (m :: * -> *) = Subscription
 rootResolver :: RootResolver IO EVENT Query Mutation Subscription
 rootResolver =
   RootResolver
-    { queryResolver = Query {a1 = WA {aText = const $ pure "test1", aInt = 0}, a2 = Nothing, a3 = Nothing},
+    { queryResolver = Query {a1 = WA {aText = pure "test1", aInt = 0}, a2 = Nothing, a3 = Nothing},
       mutationResolver = Mutation {mut1 = Nothing, mut2 = Nothing, mut3 = Nothing},
       subscriptionResolver =
         Subscription

--- a/morpheus-graphql/test/Feature/Inference/object-and-enum/introspection/query.gql
+++ b/morpheus-graphql/test/Feature/Inference/object-and-enum/introspection/query.gql
@@ -1,0 +1,79 @@
+query Get__Type {
+  enum: __type(name: "MyEnum") {
+    ...FullType
+  }
+  object: __type(name: "MyObject") {
+    ...FullType
+  }
+}
+
+fragment FullType on __Type {
+  kind
+  name
+  fields(includeDeprecated: true) {
+    name
+    args {
+      ...InputValue
+    }
+    type {
+      ...TypeRef
+    }
+    isDeprecated
+    deprecationReason
+  }
+  inputFields {
+    ...InputValue
+  }
+  interfaces {
+    ...TypeRef
+  }
+  enumValues(includeDeprecated: true) {
+    name
+    isDeprecated
+    deprecationReason
+  }
+  possibleTypes {
+    ...TypeRef
+  }
+}
+
+fragment InputValue on __InputValue {
+  name
+  type {
+    ...TypeRef
+  }
+  defaultValue
+}
+
+fragment TypeRef on __Type {
+  kind
+  name
+  ofType {
+    kind
+    name
+    ofType {
+      kind
+      name
+      ofType {
+        kind
+        name
+        ofType {
+          kind
+          name
+          ofType {
+            kind
+            name
+            ofType {
+              kind
+              name
+              ofType {
+                kind
+                name
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/morpheus-graphql/test/Feature/Inference/object-and-enum/introspection/response.json
+++ b/morpheus-graphql/test/Feature/Inference/object-and-enum/introspection/response.json
@@ -1,0 +1,44 @@
+{
+  "data": {
+    "enum": {
+      "enumValues": [
+        {
+          "deprecationReason": null,
+          "isDeprecated": false,
+          "name": "MyEnum"
+        }
+      ],
+      "fields": null,
+      "inputFields": null,
+      "interfaces": null,
+      "kind": "ENUM",
+      "name": "MyEnum",
+      "possibleTypes": null
+    },
+    "object": {
+      "enumValues": null,
+      "fields": [
+        {
+          "args": [],
+          "deprecationReason": null,
+          "isDeprecated": false,
+          "name": "_0",
+          "type": {
+            "kind": "NON_NULL",
+            "name": null,
+            "ofType": {
+              "kind": "SCALAR",
+              "name": "Int",
+              "ofType": null
+            }
+          }
+        }
+      ],
+      "inputFields": null,
+      "interfaces": [],
+      "kind": "OBJECT",
+      "name": "MyObject",
+      "possibleTypes": null
+    }
+  }
+}

--- a/morpheus-graphql/test/Feature/Inference/object-and-enum/resolving/query.gql
+++ b/morpheus-graphql/test/Feature/Inference/object-and-enum/resolving/query.gql
@@ -1,0 +1,7 @@
+{
+  enum
+  object {
+    _0
+    __typename
+  }
+}

--- a/morpheus-graphql/test/Feature/Inference/object-and-enum/resolving/response.json
+++ b/morpheus-graphql/test/Feature/Inference/object-and-enum/resolving/response.json
@@ -1,0 +1,6 @@
+{
+  "data": {
+    "field1": "(A {a1 = \"f1\", a2 = 2},B {b1 = \"f3\"},C {c1 = 4})",
+    "field2": "(A {a1 = \"f1\", a2 = 2},Arg {argValue = \"f3\"},Arg {argValue = 4})"
+  }
+}

--- a/morpheus-graphql/test/Feature/Inference/object-and-enum/resolving/response.json
+++ b/morpheus-graphql/test/Feature/Inference/object-and-enum/resolving/response.json
@@ -1,6 +1,6 @@
 {
   "data": {
-    "field1": "(A {a1 = \"f1\", a2 = 2},B {b1 = \"f3\"},C {c1 = 4})",
-    "field2": "(A {a1 = \"f1\", a2 = 2},Arg {argValue = \"f3\"},Arg {argValue = 4})"
+    "enum": "MyEnum",
+    "object": { "_0": 0, "__typename": "MyObject" }
   }
 }

--- a/morpheus-graphql/test/Feature/Input/Collections.hs
+++ b/morpheus-graphql/test/Feature/Input/Collections.hs
@@ -21,13 +21,11 @@ import Data.Morpheus.Types
     RootResolver (..),
     Undefined,
     defaultRootResolver,
-    render,
   )
 import Data.Sequence (Seq)
 import Data.Set (Set)
 import Data.Text
 import Data.Vector (Vector)
-import Debug.Trace (traceShow)
 import GHC.Generics (Generic)
 
 -- query

--- a/morpheus-graphql/test/Feature/Input/Collections.hs
+++ b/morpheus-graphql/test/Feature/Input/Collections.hs
@@ -18,9 +18,9 @@ import Data.Morpheus.Types
     GQLResponse,
     GQLType (..),
     GQLTypeOptions (..),
-    GQLTypeOptions (..),
     RootResolver (..),
-    Undefined (..),
+    Undefined,
+    defaultRootResolver,
     render,
   )
 import Data.Sequence (Seq)
@@ -60,7 +60,7 @@ data Query m = Query
 
 rootResolver :: RootResolver IO () Query Undefined Undefined
 rootResolver =
-  RootResolver
+  defaultRootResolver
     { queryResolver =
         Query
           { testSet = testRes,
@@ -71,9 +71,7 @@ rootResolver =
             testProduct = testRes,
             testMap = testRes,
             testAssoc = testRes
-          },
-      mutationResolver = Undefined,
-      subscriptionResolver = Undefined
+          }
     }
 
 app :: App () IO

--- a/morpheus-graphql/test/Feature/Input/DefaultValues.hs
+++ b/morpheus-graphql/test/Feature/Input/DefaultValues.hs
@@ -23,7 +23,8 @@ import Data.Morpheus.Types
     GQLResponse,
     ID (..),
     RootResolver (..),
-    Undefined (..),
+    Undefined,
+    defaultRootResolver,
   )
 import Data.Text (Text, pack)
 
@@ -31,19 +32,17 @@ importGQLDocument "test/Feature/Input/default-values-schema.gql"
 
 rootResolver :: RootResolver IO () Query Undefined Undefined
 rootResolver =
-  RootResolver
-    { queryResolver = Query {user, testSimple},
-      mutationResolver = Undefined,
-      subscriptionResolver = Undefined
+  defaultRootResolver
+    { queryResolver = Query {user, testSimple}
     }
   where
     user :: Applicative m => m (Maybe (User m))
     user =
-      pure
-        $ Just
-        $ User
-          { inputs = pure . pack . show
-          }
+      pure $
+        Just $
+          User
+            { inputs = pure . pack . show
+            }
     testSimple = pure . pack . show
 
 -----------------------------------

--- a/morpheus-graphql/test/Feature/Input/Enums.hs
+++ b/morpheus-graphql/test/Feature/Input/Enums.hs
@@ -9,7 +9,14 @@ module Feature.Input.Enums
 where
 
 import Data.Morpheus (interpreter)
-import Data.Morpheus.Types (GQLRequest, GQLResponse, GQLType (..), RootResolver (..), Undefined (..))
+import Data.Morpheus.Types
+  ( GQLRequest,
+    GQLResponse,
+    GQLType (..),
+    RootResolver (..),
+    Undefined,
+    defaultRootResolver,
+  )
 import GHC.Generics (Generic)
 
 data TwoCon
@@ -53,10 +60,8 @@ data Query m = Query
 
 rootResolver :: RootResolver IO () Query Undefined Undefined
 rootResolver =
-  RootResolver
-    { queryResolver = Query {test = testRes, test2 = testRes, test3 = testRes},
-      mutationResolver = Undefined,
-      subscriptionResolver = Undefined
+  defaultRootResolver
+    { queryResolver = Query {test = testRes, test2 = testRes, test3 = testRes}
     }
 
 api :: GQLRequest -> IO GQLResponse

--- a/morpheus-graphql/test/Feature/Input/Objects.hs
+++ b/morpheus-graphql/test/Feature/Input/Objects.hs
@@ -14,7 +14,8 @@ import Data.Morpheus.Types
     GQLResponse,
     GQLType (..),
     RootResolver (..),
-    Undefined (..),
+    Undefined,
+    defaultRootResolver,
   )
 import Data.Text
   ( Text,
@@ -47,10 +48,8 @@ newtype Query m = Query
 
 rootResolver :: RootResolver IO () Query Undefined Undefined
 rootResolver =
-  RootResolver
-    { queryResolver = Query {input = testRes},
-      mutationResolver = Undefined,
-      subscriptionResolver = Undefined
+  defaultRootResolver
+    { queryResolver = Query {input = testRes}
     }
 
 api :: GQLRequest -> IO GQLResponse

--- a/morpheus-graphql/test/Feature/Input/Scalars.hs
+++ b/morpheus-graphql/test/Feature/Input/Scalars.hs
@@ -14,7 +14,8 @@ import Data.Morpheus.Types
     GQLResponse,
     GQLType,
     RootResolver (..),
-    Undefined (..),
+    Undefined,
+    defaultRootResolver,
   )
 import Data.Text (Text)
 import GHC.Generics (Generic)
@@ -39,15 +40,13 @@ data Query m = Query
 
 rootResolver :: RootResolver IO () Query Undefined Undefined
 rootResolver =
-  RootResolver
+  defaultRootResolver
     { queryResolver =
         Query
           { testFloat = testRes,
             testInt = testRes,
             testString = testRes
-          },
-      mutationResolver = Undefined,
-      subscriptionResolver = Undefined
+          }
     }
 
 api :: GQLRequest -> IO GQLResponse

--- a/morpheus-graphql/test/Feature/Input/Variables.hs
+++ b/morpheus-graphql/test/Feature/Input/Variables.hs
@@ -8,6 +8,7 @@ module Feature.Input.Variables
   )
 where
 
+import Data.Kind (Type)
 import Data.Morpheus (interpreter)
 import Data.Morpheus.Types
   ( GQLRequest,
@@ -39,7 +40,7 @@ data A = A
   }
   deriving (Generic, GQLType)
 
-newtype Query (m :: * -> *) = Query
+newtype Query (m :: Type -> Type) = Query
   { q1 :: A
   }
   deriving (Generic, GQLType)

--- a/morpheus-graphql/test/Feature/Input/Variables.hs
+++ b/morpheus-graphql/test/Feature/Input/Variables.hs
@@ -15,7 +15,8 @@ import Data.Morpheus.Types
     GQLType (..),
     ResolverQ,
     RootResolver (..),
-    Undefined (..),
+    Undefined,
+    defaultRootResolver,
   )
 import Data.Text (Text)
 import GHC.Generics (Generic)
@@ -45,7 +46,7 @@ newtype Query (m :: * -> *) = Query
 
 rootResolver :: RootResolver IO () Query Undefined Undefined
 rootResolver =
-  RootResolver
+  defaultRootResolver
     { queryResolver =
         Query
           { q1 =
@@ -53,9 +54,7 @@ rootResolver =
                 { a1 = const $ return "a1Test",
                   a2 = const $ return 1
                 }
-          },
-      mutationResolver = Undefined,
-      subscriptionResolver = Undefined
+          }
     }
 
 api :: GQLRequest -> IO GQLResponse

--- a/morpheus-graphql/test/Rendering/Schema.hs
+++ b/morpheus-graphql/test/Rendering/Schema.hs
@@ -34,7 +34,7 @@ instance DecodeScalar TestScalar where
 
 importGQLDocumentWithNamespace "test/Rendering/schema.gql"
 
-type APIResolver e (m :: * -> *) =
+type APIResolver e (m :: Type -> Type) =
   RootResolver m e MyQuery MyMutation Undefined
 
 proxy :: Proxy (APIResolver () IO)

--- a/morpheus-graphql/test/Spec.hs
+++ b/morpheus-graphql/test/Spec.hs
@@ -12,6 +12,7 @@ import qualified Feature.Collision.CategoryCollisionFail as TypeCategoryCollisio
 import qualified Feature.Collision.CategoryCollisionSuccess as TypeCategoryCollisionSuccess
 import qualified Feature.Collision.NameCollision as NameCollision
 import qualified Feature.Holistic.API as Holistic
+import qualified Feature.Inference.ObjectAndEnum as ObjectAndEnum
 import qualified Feature.Inference.TaggedArguments as TaggedArguments
 import qualified Feature.Inference.TaggedArgumentsFail as TaggedArgumentsFail
 import qualified Feature.Inference.TypeGuards as TypeGuards
@@ -80,7 +81,8 @@ main =
           (UnionType.api, "union-type"),
           (TypeInference.api, "type-inference"),
           (TaggedArguments.api, "tagged-arguments"),
-          (TaggedArgumentsFail.api, "tagged-arguments-fail")
+          (TaggedArgumentsFail.api, "tagged-arguments-fail"),
+          (ObjectAndEnum.api, "object-and-enum")
         ],
       testFeatures
         "Holistic"


### PR DESCRIPTION
## Fix single variant enums

1. hides constructor of `Undefined`.

2. exposes  value `defaultRootResolver` to build `RootResolver` with undefined operations.
  
```hs
-- rootResolver with only query
rootResolver :: RootResolver IO () Query Undefined Undefined
rootResolver = defaultRootResolver { queryResolver = Query {deity} }
 ```
 
3. converts types with singe empty constructors to single value enums


fixes #721