### PR TITLE
Fix JSON instances for enums with a single variant.

### DIFF
--- a/morpheus-graphql-client/src/Data/Morpheus/Client/Declare/Aeson.hs
+++ b/morpheus-graphql-client/src/Data/Morpheus/Client/Declare/Aeson.hs
@@ -132,7 +132,7 @@ deriveFromJSON ClientTypeDefinition {clientCons = [], clientTypeName} =
     $ "Type "
       <> msg (typename clientTypeName)
       <> " Should Have at least one Constructor"
-deriveFromJSON typeD@ClientTypeDefinition {clientTypeName, clientCons}
+deriveFromJSON ClientTypeDefinition {clientTypeName, clientCons}
   | isEnum clientCons =
     defineFromJSON clientTypeName $
       aesonFromJSONEnumBody clientTypeName clientCons
@@ -143,7 +143,7 @@ deriveFromJSON
     } =
     defineFromJSON clientTypeName $
       aesonObject namespace cons
-deriveFromJSON typeD@ClientTypeDefinition {clientTypeName, clientCons}
+deriveFromJSON typeD@ClientTypeDefinition {clientTypeName}
       =
     defineFromJSON clientTypeName $
       aesonUnionObject typeD

--- a/morpheus-graphql-client/src/Data/Morpheus/Client/Declare/Aeson.hs
+++ b/morpheus-graphql-client/src/Data/Morpheus/Client/Declare/Aeson.hs
@@ -31,9 +31,6 @@ import Data.Morpheus.Client.Internal.Types
     ClientTypeDefinition (..),
     TypeNameTH (..),
   )
-import Data.Morpheus.Client.Internal.Utils
-  ( isEnum,
-  )
 import Data.Morpheus.CodeGen.Internal.TH
   ( _',
     applyCons,

--- a/morpheus-graphql-client/src/Data/Morpheus/Client/Declare/Aeson.hs
+++ b/morpheus-graphql-client/src/Data/Morpheus/Client/Declare/Aeson.hs
@@ -132,8 +132,8 @@ deriveFromJSON ClientTypeDefinition {clientCons = [], clientTypeName} =
     $ "Type "
       <> msg (typename clientTypeName)
       <> " Should Have at least one Constructor"
-deriveFromJSON ClientTypeDefinition {clientTypeName, clientCons}
-  | isEnum clientCons =
+deriveFromJSON ClientTypeDefinition {clientTypeName, clientCons, clientKind = KindEnum}
+  =
     defineFromJSON clientTypeName $
       aesonFromJSONEnumBody clientTypeName clientCons
 deriveFromJSON
@@ -237,9 +237,9 @@ deriveToJSON
 deriveToJSON
   ClientTypeDefinition
     { clientTypeName = clientTypeName@TypeNameTH {typename},
-      clientCons
-    }
-    | isEnum clientCons = instanceD (cxt []) typeDef body
+      clientCons,
+      clientKind = KindEnum
+    } = instanceD (cxt []) typeDef body
     where
       typeDef = applyCons ''ToJSON [typename]
       body = [funDSimple 'toJSON [] (aesonToJSONEnumBody clientTypeName clientCons)]

--- a/morpheus-graphql-client/src/Data/Morpheus/Client/Declare/Aeson.hs
+++ b/morpheus-graphql-client/src/Data/Morpheus/Client/Declare/Aeson.hs
@@ -132,6 +132,10 @@ deriveFromJSON ClientTypeDefinition {clientCons = [], clientTypeName} =
     $ "Type "
       <> msg (typename clientTypeName)
       <> " Should Have at least one Constructor"
+deriveFromJSON typeD@ClientTypeDefinition {clientTypeName, clientCons}
+  | isEnum clientCons =
+    defineFromJSON clientTypeName $
+      aesonFromJSONEnumBody clientTypeName clientCons
 deriveFromJSON
   ClientTypeDefinition
     { clientTypeName = clientTypeName@TypeNameTH {namespace},
@@ -140,10 +144,7 @@ deriveFromJSON
     defineFromJSON clientTypeName $
       aesonObject namespace cons
 deriveFromJSON typeD@ClientTypeDefinition {clientTypeName, clientCons}
-  | isEnum clientCons =
-    defineFromJSON clientTypeName $
-      aesonFromJSONEnumBody clientTypeName clientCons
-  | otherwise =
+      =
     defineFromJSON clientTypeName $
       aesonUnionObject typeD
 

--- a/morpheus-graphql-client/src/Data/Morpheus/Client/Internal/TH.hs
+++ b/morpheus-graphql-client/src/Data/Morpheus/Client/Internal/TH.hs
@@ -118,7 +118,6 @@ mkEntryWith conName f FieldDefinition {fieldName} =
 -- WAS WAS (User name id)
 -- >>>
 destructRecord :: TypeName -> [FieldDefinition cat s] -> PatQ
-destructRecord _ [] = wildP
 destructRecord conName fields = conP (toName conName) (vars names)
   where
     names = map (camelCaseFieldName conName . fieldName) fields

--- a/morpheus-graphql-client/src/Data/Morpheus/Client/Internal/TH.hs
+++ b/morpheus-graphql-client/src/Data/Morpheus/Client/Internal/TH.hs
@@ -118,6 +118,7 @@ mkEntryWith conName f FieldDefinition {fieldName} =
 -- WAS WAS (User name id)
 -- >>>
 destructRecord :: TypeName -> [FieldDefinition cat s] -> PatQ
+destructRecord _ [] = wildP
 destructRecord conName fields = conP (toName conName) (vars names)
   where
     names = map (camelCaseFieldName conName . fieldName) fields

--- a/morpheus-graphql-client/test/Case/Enum/Test.hs
+++ b/morpheus-graphql-client/test/Case/Enum/Test.hs
@@ -33,6 +33,7 @@ declareLocalTypesInline
     query MyQuery( $inputCity: City!) {
       city(city:$inputCity)
       cities
+      planets
     }
   |]
 
@@ -51,6 +52,9 @@ test =
                 CityCorinth,
                 CityDelphi,
                 CityArgos
+              ],
+            planets =
+              [ PlanetEarth
               ]
           }
     )

--- a/morpheus-graphql-client/test/Case/Enum/response.json
+++ b/morpheus-graphql-client/test/Case/Enum/response.json
@@ -1,6 +1,7 @@
 {
   "data": {
     "city": "Athens",
-    "cities": ["Athens", "Sparta", "Corinth", "delphi", "argos"]
+    "cities": ["Athens", "Sparta", "Corinth", "delphi", "argos"],
+    "planets": ["Earth"]
   }
 }

--- a/morpheus-graphql-client/test/Case/Enum/schema.gql
+++ b/morpheus-graphql-client/test/Case/Enum/schema.gql
@@ -7,7 +7,12 @@ enum City {
   argos
 }
 
+enum Planet {
+  Earth
+}
+
 type Query {
   city(city: City!): City!
   cities: [City!]!
+  planets: [Planet!]!
 }


### PR DESCRIPTION
Currently, the instances for an enum with a single filed are generated as

```gql
enum Planet {
  Earth
}
```
```haskell

data Planet = PlanetEarth deriving (Generic, Show, Eq)

instance ToJSON Planet where
 -- Notice it uses the type name here and not the constructor name
  toJSON Planet = omitNulls []

instance FromJSON Planet where
  fromJSON = withObject "Earth" (\v -> pure Earth)

```

I attempted a fix in this PR, which instead generates the instances as

```haskell

data Planet = PlanetEarth deriving (Generic, Show, Eq)

instance ToJSON Planet where
  toJSON = \case PlanetEarth -> "Earth"

instance FromJSON Planet where
  fromJSON = 
     = \case
            "Earth" -> pure PlanetEarth
            v -> fail ((show v) <> " is Not Valid Union Constructor")
```

~But notice that the ToJSON and FromJSON instances after the fix don't match.~(Fixed in [adbbcf0](https://github.com/morpheusgraphql/morpheus-graphql/pull/733/commits/adbbcf01e8da84daa02e49aded708206f735f9e7)) Thoughts?
Also added a test for this bug.