### PR TITLE
custom directive for default values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@ node_modules/
 .cspellcache
 .env
 .vscode/*.log
-formatter
+__ormolu__

--- a/cspell.yml
+++ b/cspell.yml
@@ -18,6 +18,7 @@ ignoreRegExpList:
 words:
   - accum
   - Aeson
+  - anyclass
   - bgroup
   - Bifunctor
   - bimap

--- a/examples/code-gen-docs/morpheus-graphql-examples-code-gen-docs.cabal
+++ b/examples/code-gen-docs/morpheus-graphql-examples-code-gen-docs.cabal
@@ -39,8 +39,8 @@ executable code-gen-docs-server
     , bytestring >=0.10.4 && <0.12
     , containers >=0.4.2.1 && <0.7
     , morpheus-graphql
-    , morpheus-graphql-app
     , morpheus-graphql-client
+    , morpheus-graphql-server
     , scotty
     , text >=1.2.3.0 && <1.3
   default-language: Haskell2010

--- a/examples/code-gen-docs/package.yaml
+++ b/examples/code-gen-docs/package.yaml
@@ -13,7 +13,7 @@ dependencies:
   - bytestring                      >= 0.10.4    && <  0.12
   - text                            >= 1.2.3.0   && <  1.3
   - morpheus-graphql
-  - morpheus-graphql-app
+  - morpheus-graphql-server
   - morpheus-graphql-client
   - scotty
   - containers                      >= 0.4.2.1       && <  0.7

--- a/examples/code-gen-docs/src/Server/Blog.hs
+++ b/examples/code-gen-docs/src/Server/Blog.hs
@@ -6,12 +6,8 @@
 
 module Server.Blog where
 
-import Data.Data (Typeable)
-import Data.Morpheus ()
-import Data.Morpheus.Kind (TYPE)
-import Data.Morpheus.Types
-import Data.Text (Text)
-import GHC.Generics (Generic)
+import Data.Morpheus.Server.CodeGen.Internal
+import Data.Morpheus.Server.Types
 import Scalars
 
 data Post m = Post

--- a/examples/code-gen/morpheus-graphql-examples-code-gen.cabal
+++ b/examples/code-gen/morpheus-graphql-examples-code-gen.cabal
@@ -51,8 +51,8 @@ executable generated-server
     , bytestring >=0.10.4 && <0.12
     , containers >=0.4.2.1 && <0.7
     , morpheus-graphql
-    , morpheus-graphql-app
     , morpheus-graphql-client
+    , morpheus-graphql-server
     , scotty
     , text >=1.2.3.0 && <1.3
   default-language: Haskell2010

--- a/examples/code-gen/package.yaml
+++ b/examples/code-gen/package.yaml
@@ -13,7 +13,7 @@ dependencies:
   - bytestring                      >= 0.10.4    && <  0.12
   - text                            >= 1.2.3.0   && <  1.3
   - morpheus-graphql
-  - morpheus-graphql-app
+  - morpheus-graphql-server
   - morpheus-graphql-client
   - scotty
   - containers                      >= 0.4.2.1       && <  0.7

--- a/examples/code-gen/src/Domains/Posts/Posts.hs
+++ b/examples/code-gen/src/Domains/Posts/Posts.hs
@@ -6,12 +6,8 @@
 
 module Domains.Posts.Posts where
 
-import Data.Data (Typeable)
-import Data.Morpheus ()
-import Data.Morpheus.Kind (TYPE)
-import Data.Morpheus.Types
-import Data.Text (Text)
-import GHC.Generics (Generic)
+import Data.Morpheus.Server.CodeGen.Internal
+import Data.Morpheus.Server.Types
 import Globals.GQLScalars
 
 data Post m = Post

--- a/examples/code-gen/src/Domains/Users/Users.hs
+++ b/examples/code-gen/src/Domains/Users/Users.hs
@@ -6,12 +6,8 @@
 
 module Domains.Users.Users where
 
-import Data.Data (Typeable)
-import Data.Morpheus ()
-import Data.Morpheus.Kind (TYPE)
-import Data.Morpheus.Types
-import Data.Text (Text)
-import GHC.Generics (Generic)
+import Data.Morpheus.Server.CodeGen.Internal
+import Data.Morpheus.Server.Types
 import Globals.GQLScalars
 
 data User m = User

--- a/examples/code-gen/src/Namespaces/Cases.hs
+++ b/examples/code-gen/src/Namespaces/Cases.hs
@@ -6,12 +6,8 @@
 
 module Namespaces.Cases where
 
-import Data.Data (Typeable)
-import Data.Morpheus ()
-import Data.Morpheus.Kind (TYPE)
-import Data.Morpheus.Types
-import Data.Text (Text)
-import GHC.Generics (Generic)
+import Data.Morpheus.Server.CodeGen.Internal
+import Data.Morpheus.Server.Types
 import Globals.GQLScalars
 
 data TestUnderscoredType = TestUnderscoredType_TestUnderscoredType

--- a/examples/code-gen/src/Namespaces/Mutation.hs
+++ b/examples/code-gen/src/Namespaces/Mutation.hs
@@ -6,12 +6,8 @@
 
 module Namespaces.Mutation where
 
-import Data.Data (Typeable)
-import Data.Morpheus ()
-import Data.Morpheus.Kind (TYPE)
-import Data.Morpheus.Types
-import Data.Text (Text)
-import GHC.Generics (Generic)
+import Data.Morpheus.Server.CodeGen.Internal
+import Data.Morpheus.Server.Types
 import Globals.GQLScalars
 
 data Query m = Query

--- a/examples/code-gen/src/Namespaces/Query.hs
+++ b/examples/code-gen/src/Namespaces/Query.hs
@@ -6,12 +6,8 @@
 
 module Namespaces.Query where
 
-import Data.Data (Typeable)
-import Data.Morpheus ()
-import Data.Morpheus.Kind (TYPE)
-import Data.Morpheus.Types
-import Data.Text (Text)
-import GHC.Generics (Generic)
+import Data.Morpheus.Server.CodeGen.Internal
+import Data.Morpheus.Server.Types
 import Globals.GQLScalars
 
 data Query m = Query

--- a/examples/code-gen/src/Namespaces/Sophisticated.hs
+++ b/examples/code-gen/src/Namespaces/Sophisticated.hs
@@ -6,12 +6,8 @@
 
 module Namespaces.Sophisticated where
 
-import Data.Data (Typeable)
-import Data.Morpheus ()
-import Data.Morpheus.Kind (TYPE)
-import Data.Morpheus.Types
-import Data.Text (Text)
-import GHC.Generics (Generic)
+import Data.Morpheus.Server.CodeGen.Internal
+import Data.Morpheus.Server.Types
 import Globals.GQLScalars
 
 data TestEnum
@@ -79,6 +75,7 @@ instance GQLType Coordinates where
       <> fieldDirective "coordinatesLatitude" Describe {text = "\n  inputValue Description: latitude\n  "}
       <> fieldDirective "coordinatesLongitude" Describe {text = "\n  inputValue Description: longitude\n  some random inputValue details\n  "}
       <> typeDirective Describe {text = "\ntype Description: Coordinates\n\nsome random text\n"}
+      <> fieldDirective "coordinatesLongitude" DefaultValue {defaultValue = Scalar (Int 4)}
 
 data Address m = Address
   { addressCity :: m Text,

--- a/examples/code-gen/src/Namespaces/Subscription.hs
+++ b/examples/code-gen/src/Namespaces/Subscription.hs
@@ -6,12 +6,8 @@
 
 module Namespaces.Subscription where
 
-import Data.Data (Typeable)
-import Data.Morpheus ()
-import Data.Morpheus.Kind (TYPE)
-import Data.Morpheus.Types
-import Data.Text (Text)
-import GHC.Generics (Generic)
+import Data.Morpheus.Server.CodeGen.Internal
+import Data.Morpheus.Server.Types
 import Globals.GQLScalars
 
 data Query m = Query

--- a/examples/code-gen/src/Namespaces/sophisticated.gql
+++ b/examples/code-gen/src/Namespaces/sophisticated.gql
@@ -50,7 +50,7 @@ input Coordinates {
   inputValue Description: longitude
   some random inputValue details
   """
-  longitude: Int!
+  longitude: Int! = 4
 }
 
 """

--- a/examples/code-gen/src/Operation/Mutation.hs
+++ b/examples/code-gen/src/Operation/Mutation.hs
@@ -6,12 +6,8 @@
 
 module Operation.Mutation where
 
-import Data.Data (Typeable)
-import Data.Morpheus ()
-import Data.Morpheus.Kind (TYPE)
-import Data.Morpheus.Types
-import Data.Text (Text)
-import GHC.Generics (Generic)
+import Data.Morpheus.Server.CodeGen.Internal
+import Data.Morpheus.Server.Types
 import Globals.GQLScalars
 
 data Query m = Query

--- a/examples/code-gen/src/Operation/Query.hs
+++ b/examples/code-gen/src/Operation/Query.hs
@@ -6,12 +6,8 @@
 
 module Operation.Query where
 
-import Data.Data (Typeable)
-import Data.Morpheus ()
-import Data.Morpheus.Kind (TYPE)
-import Data.Morpheus.Types
-import Data.Text (Text)
-import GHC.Generics (Generic)
+import Data.Morpheus.Server.CodeGen.Internal
+import Data.Morpheus.Server.Types
 import Globals.GQLScalars
 
 data Query m = Query

--- a/examples/code-gen/src/Operation/Subscription.hs
+++ b/examples/code-gen/src/Operation/Subscription.hs
@@ -6,12 +6,8 @@
 
 module Operation.Subscription where
 
-import Data.Data (Typeable)
-import Data.Morpheus ()
-import Data.Morpheus.Kind (TYPE)
-import Data.Morpheus.Types
-import Data.Text (Text)
-import GHC.Generics (Generic)
+import Data.Morpheus.Server.CodeGen.Internal
+import Data.Morpheus.Server.Types
 import Globals.GQLScalars
 
 data Query m = Query

--- a/examples/scotty/src/Server/Sophisticated/API.hs
+++ b/examples/scotty/src/Server/Sophisticated/API.hs
@@ -38,6 +38,7 @@ import Data.Morpheus.Subscriptions
 import Data.Morpheus.Types
   ( Arg (Arg),
     DecodeScalar (..),
+    DefaultValue (..),
     Deprecated (..),
     Describe (..),
     DropNamespace (..),

--- a/morpheus-graphql-client/src/Data/Morpheus/Client/CodeGen/AST.hs
+++ b/morpheus-graphql-client/src/Data/Morpheus/Client/CodeGen/AST.hs
@@ -14,7 +14,6 @@ module Data.Morpheus.Client.CodeGen.AST
     ClientPreDeclaration (..),
     DERIVING_MODE (..),
     MValue (..),
-    Printable (..),
     RequestTypeDefinition (..),
     UnionPat (..),
     ClientTypeDefinition (..),
@@ -31,6 +30,7 @@ import Data.Morpheus.CodeGen.Internal.AST
   ( CodeGenConstructor (..),
     CodeGenType,
     CodeGenTypeName,
+    PrintableValue (..),
     TypeClassInstance,
     printTHName,
   )
@@ -44,7 +44,6 @@ import Data.Morpheus.CodeGen.TH
   )
 import Data.Morpheus.Types.Internal.AST (FieldName, OperationType, TypeKind, TypeName, unpackName)
 import Language.Haskell.TH
-import Language.Haskell.TH.Syntax (Lift (..))
 import Prettyprinter
   ( Doc,
     Pretty (..),
@@ -90,17 +89,8 @@ instance Pretty ClientDeclaration where
   pretty (ClientTypeDeclaration def) = pretty def
   pretty (InstanceDeclaration _ def) = pretty def
 
-data Printable where
-  Printable :: forall a. (Show a, Lift a) => a -> Printable
-
-instance Pretty Printable where
-  pretty (Printable x) = pretty (show x :: String)
-
-instance PrintExp Printable where
-  printExp (Printable x) = [|x|]
-
 data ClientMethod
-  = PrintableMethod Printable
+  = PrintableMethod PrintableValue
   | FunctionNameMethod Name
   | MatchMethod ValueMatch
   | ToJSONObjectMethod Name [(FieldName, Name, Name)]

--- a/morpheus-graphql-client/src/Data/Morpheus/Client/CodeGen/Interpreting/PreDeclarations.hs
+++ b/morpheus-graphql-client/src/Data/Morpheus/Client/CodeGen/Interpreting/PreDeclarations.hs
@@ -25,7 +25,6 @@ import Data.Morpheus.Client.CodeGen.AST
     ClientPreDeclaration (..),
     DERIVING_MODE (..),
     MValue (..),
-    Printable (..),
     RequestTypeDefinition (..),
     UnionPat (..),
   )
@@ -40,6 +39,7 @@ import Data.Morpheus.CodeGen.Internal.AST
     CodeGenType (..),
     CodeGenTypeName (typename),
     MethodArgument (..),
+    PrintableValue (..),
     TypeClassInstance (..),
     fromTypeName,
     getFullName,
@@ -78,9 +78,9 @@ getRequestInstance RequestTypeDefinition {..} =
     }
   where
     typeClassMethods =
-      [ ('__name, ProxyArgument, PrintableMethod $ Printable requestName),
-        ('__query, ProxyArgument, PrintableMethod $ Printable requestQuery),
-        ('__type, ProxyArgument, PrintableMethod $ Printable requestType)
+      [ ('__name, ProxyArgument, PrintableMethod $ PrintableValue requestName),
+        ('__query, ProxyArgument, PrintableMethod $ PrintableValue requestQuery),
+        ('__type, ProxyArgument, PrintableMethod $ PrintableValue requestType)
       ]
 
 -- FromJSON

--- a/morpheus-graphql-code-gen-utils/src/Data/Morpheus/CodeGen/TH.hs
+++ b/morpheus-graphql-code-gen-utils/src/Data/Morpheus/CodeGen/TH.hs
@@ -39,6 +39,7 @@ import Data.Morpheus.CodeGen.Internal.AST
     DerivingClass (..),
     FIELD_TYPE_WRAPPER (..),
     MethodArgument (..),
+    PrintableValue (..),
     TypeClassInstance (..),
     TypeValue (..),
     getFullName,
@@ -229,6 +230,7 @@ instance PrintExp TypeValue where
   printExp (TypedValueMaybe (Just x)) = appE (conE 'Just) (printExp x)
   printExp (TypedValueMaybe Nothing) = conE 'Nothing
   printExp (TypeValueList xs) = listE $ map printExp xs
+  printExp (PrintableTypeValue x) = printExp x
 
 genName :: DerivingClass -> Name
 genName GENERIC = ''Generic
@@ -348,3 +350,6 @@ instance PrintDec CodeGenType where
         Nothing
         (map printConstructor cgConstructors)
         [printDerivClause cgDerivations]
+
+instance PrintExp PrintableValue where
+  printExp (PrintableValue x) = [|x|]

--- a/morpheus-graphql-code-gen/app/CLI/Generator.hs
+++ b/morpheus-graphql-code-gen/app/CLI/Generator.hs
@@ -41,12 +41,8 @@ processServerDocument BuildConfig {..} moduleName schema = do
       ModuleDefinition
         { moduleName,
           imports =
-            [ ("Data.Data", ["Typeable"]),
-              ("Data.Morpheus.Kind", ["TYPE"]),
-              ("Data.Morpheus.Types", ["*"]),
-              ("Data.Morpheus", []),
-              ("Data.Text", ["Text"]),
-              ("GHC.Generics", ["Generic"])
+            [ ("Data.Morpheus.Server.CodeGen.Internal", ["*"]),
+              ("Data.Morpheus.Server.Types", ["*"])
             ]
               <> map (,["*"]) globalImports,
           extensions =

--- a/morpheus-graphql-code-gen/src/Data/Morpheus/CodeGen/Server/Internal/AST.hs
+++ b/morpheus-graphql-code-gen/src/Data/Morpheus/CodeGen/Server/Internal/AST.hs
@@ -94,8 +94,7 @@ instance Pretty ServerDirectiveUsage where
 data GQLTypeDefinition = GQLTypeDefinition
   { gqlTarget :: CodeGenTypeName,
     gqlKind :: Kind,
-    gqlTypeDirectiveUses :: [ServerDirectiveUsage],
-    gqlTypeDefaultValues :: Map Text (Value CONST)
+    gqlTypeDirectiveUses :: [ServerDirectiveUsage]
   }
   deriving (Show)
 

--- a/morpheus-graphql-core/src/Data/Morpheus/Types/Internal/AST/Fields.hs
+++ b/morpheus-graphql-core/src/Data/Morpheus/Types/Internal/AST/Fields.hs
@@ -295,6 +295,8 @@ instance NameCollision GQLError (FieldDefinition cat s) where
 instance RenderGQL (FieldDefinition cat s) where
   renderGQL FieldDefinition {fieldContent = Just (FieldArgs args), ..} =
     renderGQL fieldName <> renderGQL args <> ": " <> renderGQL fieldType <> addDirectives fieldDirectives
+  renderGQL FieldDefinition {fieldContent = Just (DefaultInputValue x), ..} =
+    renderEntry fieldName fieldType <> " = " <> renderGQL x <> addDirectives fieldDirectives
   renderGQL FieldDefinition {..} =
     renderEntry fieldName fieldType <> addDirectives fieldDirectives
 

--- a/morpheus-graphql-server/morpheus-graphql-server.cabal
+++ b/morpheus-graphql-server/morpheus-graphql-server.cabal
@@ -278,6 +278,7 @@ library
       Data.Morpheus.Server
       Data.Morpheus.Server.Resolvers
       Data.Morpheus.Server.Types
+      Data.Morpheus.Server.CodeGen.Internal
   other-modules:
       Data.Morpheus.Server.Deriving.App
       Data.Morpheus.Server.Deriving.Channels

--- a/morpheus-graphql-server/package.yaml
+++ b/morpheus-graphql-server/package.yaml
@@ -36,12 +36,13 @@ library:
     - Data.Morpheus.Server
     - Data.Morpheus.Server.Resolvers
     - Data.Morpheus.Server.Types
-  ghc-options: '-Wall'
+    - Data.Morpheus.Server.CodeGen.Internal
+  ghc-options: "-Wall"
 tests:
   morpheus-graphql-server-test:
     main: Spec.hs
     source-dirs: test
-    ghc-options: '-Wall'
+    ghc-options: "-Wall"
     dependencies:
       - aeson                           >=  1.4.4   &&  <  3.0.0
       - file-embed                      >=  0.0.10  &&  <  1.0.0

--- a/morpheus-graphql-server/src/Data/Morpheus/Server/CodeGen/Internal.hs
+++ b/morpheus-graphql-server/src/Data/Morpheus/Server/CodeGen/Internal.hs
@@ -1,0 +1,12 @@
+module Data.Morpheus.Server.CodeGen.Internal
+  ( Typeable,
+    Text,
+    Generic,
+  )
+where
+
+import Data.Data (Typeable)
+-- add type class instances
+import Data.Morpheus.Server.Deriving.App ()
+import Data.Text (Text)
+import GHC.Generics (Generic)

--- a/morpheus-graphql-server/src/Data/Morpheus/Server/Deriving/Schema.hs
+++ b/morpheus-graphql-server/src/Data/Morpheus/Server/Deriving/Schema.hs
@@ -94,6 +94,7 @@ import Data.Morpheus.Types.Internal.AST
     OUT,
     QUERY,
     SUBSCRIPTION,
+    ScalarDefinition (..),
     Schema (..),
     TRUE,
     TypeCategory,
@@ -102,6 +103,7 @@ import Data.Morpheus.Types.Internal.AST
     TypeName,
     TypeRef (..),
     UnionMember (memberName),
+    Value,
     fieldsToArguments,
     mkField,
   )
@@ -192,6 +194,9 @@ instance DeriveTypeConstraint IN a => DeriveKindedType IN TYPE a where
 
 instance DeriveType cat a => DeriveKindedType cat CUSTOM (Resolver o e m a) where
   deriveKindedType _ = deriveType (Proxy @a)
+
+instance DeriveKindedType cat CUSTOM (Value CONST) where
+  deriveKindedType = insertTypeContent (const $ pure $ DataScalar $ ScalarDefinition pure) . setKind (Proxy @LEAF)
 
 instance DeriveType cat [(k, v)] => DeriveKindedType cat CUSTOM (Map k v) where
   deriveKindedType _ = deriveType (Proxy @[(k, v)])

--- a/morpheus-graphql-server/src/Data/Morpheus/Server/Deriving/Schema/Enum.hs
+++ b/morpheus-graphql-server/src/Data/Morpheus/Server/Deriving/Schema/Enum.hs
@@ -36,7 +36,6 @@ import Data.Morpheus.Types.Internal.AST
     mkEnumContent,
     mkType,
     unitTypeName,
-    unpackName,
   )
 
 buildEnumTypeContent :: GQLType a => KindedType kind a -> [TypeName] -> SchemaT c (TypeContent TRUE kind CONST)
@@ -46,11 +45,10 @@ buildEnumTypeContent p@OutputType enumCons = DataEnum <$> traverse (mkEnumValue 
 mkEnumValue :: GQLType a => f a -> TypeName -> SchemaT c (DataEnumValue CONST)
 mkEnumValue proxy enumName = do
   enumDirectives <- deriveEnumDirectives proxy enumName
-  let desc = lookupDescription proxy (unpackName enumName)
   pure
     DataEnumValue
       { enumName = visitEnumName proxy enumName,
-        enumDescription = visitEnumValueDescription proxy enumName desc,
+        enumDescription = visitEnumValueDescription proxy enumName (lookupDescription proxy enumName),
         ..
       }
 

--- a/morpheus-graphql-server/src/Data/Morpheus/Server/Deriving/Schema/Internal.hs
+++ b/morpheus-graphql-server/src/Data/Morpheus/Server/Deriving/Schema/Internal.hs
@@ -48,22 +48,25 @@ import Data.Morpheus.Types.Internal.AST
   ( CONST,
     Description,
     FieldContent (..),
+    FieldName,
+    Name,
     Schema (..),
     TRUE,
     VALID,
+    unpackName,
   )
 import Language.Haskell.TH (Exp, Q)
 import Relude hiding (empty)
 
-lookupDescription :: GQLType a => f a -> Text -> Maybe Description
-lookupDescription proxy name = name `M.lookup` getDescriptions proxy
+lookupDescription :: GQLType a => f a -> Name t -> Maybe Description
+lookupDescription proxy name = unpackName name `M.lookup` getDescriptions proxy
 
 lookupFieldContent ::
   GQLType a =>
   KindedType kind a ->
-  Text ->
+  FieldName ->
   Maybe (FieldContent TRUE kind CONST)
-lookupFieldContent proxy@InputType key = DefaultInputValue <$> key `M.lookup` defaultValues proxy
+lookupFieldContent proxy@InputType key = DefaultInputValue <$> unpackName key `M.lookup` defaultValues proxy
 lookupFieldContent OutputType _ = Nothing
 
 fromSchema :: GQLResult (Schema VALID) -> Q Exp

--- a/morpheus-graphql-server/src/Data/Morpheus/Server/Deriving/Schema/Object.hs
+++ b/morpheus-graphql-server/src/Data/Morpheus/Server/Deriving/Schema/Object.hs
@@ -21,6 +21,7 @@ import Data.Morpheus.Internal.Utils
   )
 import Data.Morpheus.Server.Deriving.Schema.Directive
   ( deriveFieldDirectives,
+    visitFieldContent,
     visitFieldDescription,
     visitFieldName,
   )
@@ -63,7 +64,6 @@ import Data.Morpheus.Types.Internal.AST
     msg,
     unitFieldName,
     unitTypeName,
-    unpackName,
     unsafeFromFields,
   )
 import Relude hiding (empty)
@@ -135,10 +135,8 @@ setGQLTypeProps proxy FieldDefinition {..} = do
   pure
     FieldDefinition
       { fieldName = visitFieldName proxy fieldName,
-        fieldDescription = visitFieldDescription proxy fieldName (lookupDescription proxy key),
-        fieldContent = lookupFieldContent proxy key <|> fieldContent,
+        fieldDescription = visitFieldDescription proxy fieldName (lookupDescription proxy fieldName),
+        fieldContent = visitFieldContent proxy fieldName $ lookupFieldContent proxy fieldName <|> fieldContent,
         fieldDirectives = dirs,
         ..
       }
-  where
-    key = unpackName fieldName

--- a/morpheus-graphql-server/src/Data/Morpheus/Server/Types.hs
+++ b/morpheus-graphql-server/src/Data/Morpheus/Server/Types.hs
@@ -78,6 +78,8 @@ module Data.Morpheus.Server.Types
     Rename (..),
     InputTypeNamespace (..),
     DropNamespace (..),
+    DefaultValue (..),
+    Value (..),
   )
 where
 
@@ -102,7 +104,8 @@ import Data.Morpheus.Server.Resolvers
     defaultRootResolver,
   )
 import Data.Morpheus.Server.Types.DirectiveDefinitions
-  ( Deprecated (..),
+  ( DefaultValue (..),
+    Deprecated (..),
     Describe (..),
     DropNamespace (..),
     Prefixes (..),
@@ -158,5 +161,6 @@ import Data.Morpheus.Types.Internal.AST
     QUERY,
     SUBSCRIPTION,
     ScalarValue (..),
+    Value (..),
   )
 import Relude hiding (Undefined)

--- a/morpheus-graphql-server/src/Data/Morpheus/Server/Types/DirectiveDefinitions.hs
+++ b/morpheus-graphql-server/src/Data/Morpheus/Server/Types/DirectiveDefinitions.hs
@@ -13,6 +13,7 @@ module Data.Morpheus.Server.Types.DirectiveDefinitions
     Describe (..),
     Rename (..),
     DropNamespace (..),
+    DefaultValue (..),
   )
 where
 
@@ -28,9 +29,7 @@ import Data.Morpheus.Server.Types.Visitors
     VisitField (..),
     VisitType (..),
   )
-import Data.Morpheus.Types.Internal.AST
-  ( DirectiveLocation (..),
-  )
+import Data.Morpheus.Types.Internal.AST (CONST, DirectiveLocation (..), Value)
 import Data.Text (drop, length, pack, unpack)
 import Relude hiding (drop, length)
 
@@ -167,3 +166,18 @@ instance GQLDirective DropNamespace where
 instance VisitType DropNamespace where
   visitFieldNames DropNamespace {dropNamespace} = pack . stripFieldNamespace dropNamespace . unpack
   visitEnumNames DropNamespace {dropNamespace} = pack . stripConstructorNamespace dropNamespace . unpack
+
+newtype DefaultValue = DefaultValue
+  { defaultValue :: Value CONST
+  }
+  deriving
+    ( Generic,
+      GQLType
+    )
+
+instance GQLDirective DefaultValue where
+  type DIRECTIVE_LOCATIONS DefaultValue = '[ 'INPUT_FIELD_DEFINITION]
+  excludeFromSchema _ = True
+
+instance VisitField DefaultValue where
+  visitFieldDefaultValue DefaultValue {defaultValue} _ = Just defaultValue

--- a/morpheus-graphql-server/src/Data/Morpheus/Server/Types/Directives.hs
+++ b/morpheus-graphql-server/src/Data/Morpheus/Server/Types/Directives.hs
@@ -17,26 +17,29 @@ module Data.Morpheus.Server.Types.Directives
     ToLocations (..),
     getLocations,
     -- visitors
-    visitTypeName',
-    visitTypeDescription',
-    visitFieldName',
-    visitFieldDescription',
-    visitEnumName',
     visitEnumDescription',
-    visitFieldNames',
+    visitEnumName',
     visitEnumNames',
+    visitFieldDefaultValue',
+    visitFieldDescription',
+    visitFieldName',
+    visitFieldNames',
+    visitTypeDescription',
+    visitTypeName',
   )
 where
 
 import Data.Morpheus.Server.Types.TypeName (getTypename)
 import qualified Data.Morpheus.Server.Types.Visitors as Visitors
 import Data.Morpheus.Types.Internal.AST
-  ( Description,
+  ( CONST,
+    Description,
     DirectiveLocation (..),
     FALSE,
     FieldName,
     TRUE,
     TypeName,
+    Value,
     packName,
     unpackName,
   )
@@ -171,17 +174,23 @@ visitFieldName' = __visitFieldName (Proxy :: Proxy (ALLOWED a FIELD_VISITOR_KIND
 visitFieldDescription' :: forall a. GQLDirective a => a -> Maybe Description -> Maybe Description
 visitFieldDescription' = __visitFieldDescription (Proxy :: Proxy (ALLOWED a FIELD_VISITOR_KIND))
 
+visitFieldDefaultValue' :: forall a. GQLDirective a => a -> Maybe (Value CONST) -> Maybe (Value CONST)
+visitFieldDefaultValue' = __visitFieldDefaultValue (Proxy :: Proxy (ALLOWED a FIELD_VISITOR_KIND))
+
 class VISIT_FIELD a (t :: Bool) where
   __visitFieldName :: f t -> a -> FieldName -> FieldName
   __visitFieldDescription :: f t -> a -> Maybe Description -> Maybe Description
+  __visitFieldDefaultValue :: f t -> a -> Maybe (Value CONST) -> Maybe (Value CONST)
 
 instance VISIT_FIELD a FALSE where
   __visitFieldName _ _ = id
   __visitFieldDescription _ _ = id
+  __visitFieldDefaultValue _ _ = id
 
 instance Visitors.VisitField a => VISIT_FIELD a TRUE where
   __visitFieldName _ x name = packName $ Visitors.visitFieldName x (unpackName name)
   __visitFieldDescription _ = Visitors.visitFieldDescription
+  __visitFieldDefaultValue _ = Visitors.visitFieldDefaultValue
 
 -- VISIT_ENUM
 

--- a/morpheus-graphql-server/src/Data/Morpheus/Server/Types/GQLType.hs
+++ b/morpheus-graphql-server/src/Data/Morpheus/Server/Types/GQLType.hs
@@ -7,7 +7,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}

--- a/morpheus-graphql-server/src/Data/Morpheus/Server/Types/Visitors.hs
+++ b/morpheus-graphql-server/src/Data/Morpheus/Server/Types/Visitors.hs
@@ -16,6 +16,7 @@ module Data.Morpheus.Server.Types.Visitors
   )
 where
 
+import Data.Morpheus.Types.Internal.AST (CONST, Value)
 import Relude
 
 class VisitType a where
@@ -43,6 +44,9 @@ class VisitField a where
 
   visitFieldDescription :: a -> Maybe Text -> Maybe Text
   visitFieldDescription _ = id
+
+  visitFieldDefaultValue :: a -> Maybe (Value CONST) -> Maybe (Value CONST)
+  visitFieldDefaultValue _ = id
 
 class VisitEnum a where
   visitEnumName :: a -> Text -> Text

--- a/morpheus-graphql/src/Data/Morpheus/Types.hs
+++ b/morpheus-graphql/src/Data/Morpheus/Types.hs
@@ -82,6 +82,7 @@ module Data.Morpheus.Types
     dropNamespaceOptions,
     DropNamespace (..),
     Rename (..),
+    DefaultValue (..),
   )
 where
 
@@ -92,6 +93,7 @@ import Data.Morpheus.Server.Types
     Arg (..),
     DecodeScalar (..),
     DecodeWrapper (..),
+    DefaultValue (..),
     Deprecated (..),
     Describe (..),
     DropNamespace (..),

--- a/morpheus-graphql/test/Feature/Input/DefaultValues.hs
+++ b/morpheus-graphql/test/Feature/Input/DefaultValues.hs
@@ -19,7 +19,8 @@ where
 import Data.Morpheus (interpreter)
 import Data.Morpheus.Document (importGQLDocument)
 import Data.Morpheus.Types
-  ( GQLRequest,
+  ( DefaultValue (..),
+    GQLRequest,
     GQLResponse,
     ID (..),
     RootResolver (..),

--- a/morpheus-graphql/test/Rendering/Schema.hs
+++ b/morpheus-graphql/test/Rendering/Schema.hs
@@ -22,6 +22,7 @@ import Data.Morpheus.Document
   )
 import Data.Morpheus.Types
   ( DecodeScalar (..),
+    DefaultValue (..),
     DropNamespace (..),
     ID,
     Rename (..),

--- a/morpheus-graphql/test/Rendering/schema.gql
+++ b/morpheus-graphql/test/Rendering/schema.gql
@@ -20,7 +20,7 @@ enum testCharCases {
 
 input Coordinates @TestDirective(name: "SomeName") {
   latitude: TestScalar!
-  longitude: Int! @TestDirective(name: "SomeName")
+  longitude: Int! = 4 @TestDirective(name: "SomeName")
 }
 
 type Address {

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,14 +1,15 @@
-allow-newer: true
-resolver: nightly-2022-10-10
+resolver: lts-18.10
 save-hackage-creds: false
 packages:
   - examples/client
   - examples/code-gen
   - examples/code-gen-docs
   - examples/scotty
+  - examples/scotty-fraxl
   - examples/scotty-haxl
   - examples/scotty-freer-simple
   - examples/servant
+  - morpheus-graphql-benchmarks
   - morpheus-graphql-tests
   - morpheus-graphql-core
   - morpheus-graphql-code-gen-utils
@@ -19,6 +20,10 @@ packages:
   - morpheus-graphql-server
   - morpheus-graphql
 extra-deps:
+  - dependent-map-0.2.4.0
+  - dependent-sum-0.4
+  - fastsum-0.1.1.1
   - fraxl-0.3.0.0
+  - graphql-0.11.1.0
   - haxl-2.4.0.0
   - type-aligned-0.9.6


### PR DESCRIPTION
- new custom directive DefaultValue
- GQL printer supports  defaultValues
- deprecated `GQLType.defaultValues`
- FieldVisitor provides `visitFieldDefaultValue`
- TH may require importing directive type DefaultValue