### PR TITLE
Fix Yesod ws example subscription

### DIFF
--- a/examples/yesod-pubsub/client/src/index.js
+++ b/examples/yesod-pubsub/client/src/index.js
@@ -10,7 +10,7 @@ let client = GqlClient({
 })
 
 gql.subscribe(
-	"subscription { sub_counter() }",
+	"subscription { subCounter() }",
 	(res) => {
 		console.log(">>> Result", JSON.stringify(res));
 	}


### PR DESCRIPTION
Yesod-pubsub example had a minor issue where the client was sending a malformed subscription request.